### PR TITLE
Release 1.2.9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,104 @@
 /bin
 build/
 dist/
+
+### Usagi index files ###
+derivedIndex/
+mainIndex/
+sleepyCat/
+ConceptClassIds.txt
+DomainIds.txt
+VocabularyIds.txt
+vocabularyVersion.txt
+
+### Intellij ###
+# Created by https://www.gitignore.io/api/intellij
+# Edit at https://www.gitignore.io/?templates=intellij
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and WebStorm
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+.idea/
+# User-specific stuff
+.idea/**/workspace.xml
+.idea/**/tasks.xml
+.idea/**/usage.statistics.xml
+.idea/**/dictionaries
+.idea/**/shelf
+
+# Generated files
+.idea/**/contentModel.xml
+
+# Sensitive or high-churn files
+.idea/**/dataSources/
+.idea/**/dataSources.ids
+.idea/**/dataSources.local.xml
+.idea/**/sqlDataSources.xml
+.idea/**/dynamic.xml
+.idea/**/uiDesigner.xml
+.idea/**/dbnavigator.xml
+
+# Gradle
+.idea/**/gradle.xml
+.idea/**/libraries
+
+# Gradle and Maven with auto-import
+# When using Gradle or Maven with auto-import, you should exclude module files,
+# since they will be recreated, and may cause churn.  Uncomment if using
+# auto-import.
+# .idea/modules.xml
+# .idea/*.iml
+# .idea/modules
+# *.iml
+# *.ipr
+
+# CMake
+cmake-build-*/
+
+# Mongo Explorer plugin
+.idea/**/mongoSettings.xml
+
+# File-based project format
+*.iws
+
+# IntelliJ
+out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Cursive Clojure plugin
+.idea/replstate.xml
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+
+# Editor-based Rest Client
+.idea/httpRequests
+
+# Android studio 3.1+ serialized cache file
+.idea/caches/build_file_checksums.ser
+
+### Intellij Patch ###
+# Comment Reason: https://github.com/joeblau/gitignore.io/issues/186#issuecomment-215987721
+
+# *.iml
+# modules.xml
+# .idea/misc.xml
+# *.ipr
+
+# Sonarlint plugin
+.idea/**/sonarlint/
+
+# SonarQube Plugin
+.idea/**/sonarIssues.xml
+
+# Markdown Navigator plugin
+.idea/**/markdown-navigator.xml
+.idea/**/markdown-navigator/
+
+# End of https://www.gitignore.io/api/intellij

--- a/Usagi.iml
+++ b/Usagi.iml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$/src" isTestSource="false" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="library" name="lib" level="project" />
+    <orderEntry type="library" name="R User Library" level="project" />
+    <orderEntry type="library" name="R Skeletons" level="application" />
+  </component>
+</module>

--- a/src/org/ohdsi/usagi/ui/AboutDialog.java
+++ b/src/org/ohdsi/usagi/ui/AboutDialog.java
@@ -40,10 +40,9 @@ import javax.swing.event.HyperlinkListener;
 public class AboutDialog extends JDialog {
 
 	private static final long	serialVersionUID	= 2028328868610404663L;
-	private JEditorPane			text;
 
 	public AboutDialog() {
-		setTitle("About Usagi");
+		setTitle("About Usagi v" + UsagiMain.version);
 		setLayout(new GridBagLayout());
 
 		GridBagConstraints g = new GridBagConstraints();
@@ -60,9 +59,11 @@ public class AboutDialog extends JDialog {
 		g.gridx = 1;
 		g.gridy = 0;
 
-		text = new JEditorPane(
+		JEditorPane text = new JEditorPane(
 				"text/html",
-				"Usagi was developed by Martijn Schuemie in <a href=\"http://ohdsi.org\">Observational Health Data Sciences and Informatics</a> (OHDSI).<br/><br/>For help, please review the <a href =\"http://www.ohdsi.org/web/wiki/doku.php?id=documentation:software:usagi\">Usagi Wiki</a>.");
+				"Usagi was developed by Martijn Schuemie" +
+						"<br/>in <a href=\"http://ohdsi.org\">Observational Health Data Sciences and Informatics</a> (OHDSI)." +
+						"<br/><br/>For help, please review the <a href =\"http://www.ohdsi.org/web/wiki/doku.php?id=documentation:software:usagi\">Usagi Wiki</a>.");
 
 		text.setEditable(false);
 		text.setOpaque(false);

--- a/src/org/ohdsi/usagi/ui/CodeSelectedListener.java
+++ b/src/org/ohdsi/usagi/ui/CodeSelectedListener.java
@@ -18,5 +18,7 @@ package org.ohdsi.usagi.ui;
 import org.ohdsi.usagi.CodeMapping;
 
 public interface CodeSelectedListener {
-	public void codeSelected(CodeMapping codeMapping);
+	void codeSelected(CodeMapping codeMapping);
+	void addCodeMultiSelected(CodeMapping codeMapping);
+	void clearCodeMultiSelected();
 }

--- a/src/org/ohdsi/usagi/ui/ConceptTableModel.java
+++ b/src/org/ohdsi/usagi/ui/ConceptTableModel.java
@@ -130,7 +130,7 @@ class ConceptTableModel extends AbstractTableModel {
 	}
 
 	public boolean isCellEditable(int row, int col) {
-		return true;
+		return false;
 	}
 
 	public void setValueAt(Object value, int row, int col) {

--- a/src/org/ohdsi/usagi/ui/DataChangeListener.java
+++ b/src/org/ohdsi/usagi/ui/DataChangeListener.java
@@ -17,19 +17,22 @@ package org.ohdsi.usagi.ui;
 
 public interface DataChangeListener {
 
-	DataChangeEvent	APPROVE_EVENT		= new DataChangeEvent(true, false);
-	DataChangeEvent	SIMPLE_UPDATE_EVENT	= new DataChangeEvent(false, false);
-	DataChangeEvent	RESTRUCTURE_EVENT	= new DataChangeEvent(false, true);
+	DataChangeEvent	APPROVE_EVENT		= new DataChangeEvent(true, false, false);
+	DataChangeEvent	SIMPLE_UPDATE_EVENT	= new DataChangeEvent(false, false, false);
+	DataChangeEvent	MULTI_UPDATE_EVENT	= new DataChangeEvent(false, false, true);
+	DataChangeEvent	RESTRUCTURE_EVENT	= new DataChangeEvent(false, true, false);
 
 	void dataChanged(DataChangeEvent event);
 
 	class DataChangeEvent {
-		public DataChangeEvent(boolean approved, boolean structureChange) {
+		public DataChangeEvent(boolean approved, boolean structureChange, boolean multiUpdate) {
 			this.approved = approved;
 			this.structureChange = structureChange;
+			this.multiUpdate = multiUpdate;
 		}
 
 		public boolean	approved;
 		public boolean	structureChange;
+		public boolean	multiUpdate	= false;
 	}
 }

--- a/src/org/ohdsi/usagi/ui/DataChangeListener.java
+++ b/src/org/ohdsi/usagi/ui/DataChangeListener.java
@@ -17,19 +17,19 @@ package org.ohdsi.usagi.ui;
 
 public interface DataChangeListener {
 
-	public static DataChangeEvent	APPROVE_EVENT		= new DataChangeEvent(true, false);
-	public static DataChangeEvent	SIMPLE_UPDATE_EVENT	= new DataChangeEvent(false, false);
-	public static DataChangeEvent	RESTRUCTURE_EVENT	= new DataChangeEvent(false, true);
+	DataChangeEvent	APPROVE_EVENT		= new DataChangeEvent(true, false);
+	DataChangeEvent	SIMPLE_UPDATE_EVENT	= new DataChangeEvent(false, false);
+	DataChangeEvent	RESTRUCTURE_EVENT	= new DataChangeEvent(false, true);
 
-	public void dataChanged(DataChangeEvent event);
+	void dataChanged(DataChangeEvent event);
 
-	public static class DataChangeEvent {
+	class DataChangeEvent {
 		public DataChangeEvent(boolean approved, boolean structureChange) {
 			this.approved = approved;
 			this.structureChange = structureChange;
 		}
 
-		public boolean	approved		= false;
-		public boolean	structureChange	= false;
+		public boolean	approved;
+		public boolean	structureChange;
 	}
 }

--- a/src/org/ohdsi/usagi/ui/ExportSourceToConceptMapDialog.java
+++ b/src/org/ohdsi/usagi/ui/ExportSourceToConceptMapDialog.java
@@ -45,6 +45,7 @@ public class ExportSourceToConceptMapDialog extends JDialog {
 
 	private JTextField			sourceVocabularyIdField;
 	private static final long	serialVersionUID	= -6846083121849826818L;
+	private boolean exportUnapproved = false;
 
 	public ExportSourceToConceptMapDialog() {
 		setTitle("Export to source_to_concept_map");
@@ -73,29 +74,21 @@ public class ExportSourceToConceptMapDialog extends JDialog {
 		buttonPanel.add(Box.createHorizontalGlue());
 		JButton cancelButton = new JButton("Cancel");
 		cancelButton.setToolTipText("Cancel the export");
-		cancelButton.addActionListener(new ActionListener() {
-
-			@Override
-			public void actionPerformed(ActionEvent arg0) {
-				setVisible(false);
-			}
-		});
+		cancelButton.addActionListener(arg0 -> setVisible(false));
 		buttonPanel.add(cancelButton);
 		JButton exportButton = new JButton("Export");
 		exportButton.setToolTipText("Select the filename and export using these settings");
-		exportButton.addActionListener(new ActionListener() {
-
-			@Override
-			public void actionPerformed(ActionEvent arg0) {
-				export();
-			}
-		});
+		exportButton.addActionListener(arg0 -> export());
 		buttonPanel.add(exportButton);
 		add(buttonPanel, g);
 
 		pack();
 		setModal(true);
 		setLocationRelativeTo(Global.frame);
+	}
+
+	public void setExportUnapproved(boolean exportUnapproved) {
+		this.exportUnapproved = exportUnapproved;
 	}
 
 	private void export() {
@@ -117,7 +110,7 @@ public class ExportSourceToConceptMapDialog extends JDialog {
 	private void writeToCsvFile(String filename) {
 		WriteCSVFileWithHeader out = new WriteCSVFileWithHeader(filename);
 		for (CodeMapping mapping : Global.mapping)
-			if (mapping.mappingStatus == MappingStatus.APPROVED) {
+			if (exportUnapproved || mapping.mappingStatus == MappingStatus.APPROVED) {
 				List<Concept> targetConcepts;
 				if (mapping.targetConcepts.size() == 0) {
 					targetConcepts = new ArrayList<Concept>(1);
@@ -132,7 +125,7 @@ public class ExportSourceToConceptMapDialog extends JDialog {
 					row.add("source_vocabulary_id", sourceVocabularyIdField.getText());
 					row.add("source_code_description", mapping.sourceCode.sourceName);
 					row.add("target_concept_id", targetConcept.conceptId);
-					row.add("target_vocabulary_id", targetConcept.vocabularyId);
+					row.add("target_vocabulary_id", targetConcept.conceptId == 0 ? "None" : targetConcept.vocabularyId );
 					row.add("valid_start_date", "1970-01-01");
 					row.add("valid_end_date", "2099-12-31");
 					row.add("invalid_reason", "");

--- a/src/org/ohdsi/usagi/ui/ExportSourceToConceptMapDialog.java
+++ b/src/org/ohdsi/usagi/ui/ExportSourceToConceptMapDialog.java
@@ -105,6 +105,7 @@ public class ExportSourceToConceptMapDialog extends JDialog {
 		fileChooser.setDialogTitle("Export");
 		if (fileChooser.showSaveDialog(Global.frame) == JFileChooser.APPROVE_OPTION) {
 			File file = fileChooser.getSelectedFile();
+			Global.folder = file.getParentFile().getAbsolutePath();
 			if (!file.getName().toLowerCase().endsWith(".csv"))
 				file = new File(file.getAbsolutePath() + ".csv");
 

--- a/src/org/ohdsi/usagi/ui/Global.java
+++ b/src/org/ohdsi/usagi/ui/Global.java
@@ -19,21 +19,7 @@ import javax.swing.JFrame;
 
 import org.ohdsi.usagi.BerkeleyDbEngine;
 import org.ohdsi.usagi.UsagiSearchEngine;
-import org.ohdsi.usagi.ui.actions.AboutAction;
-import org.ohdsi.usagi.ui.actions.ApplyPreviousMappingAction;
-import org.ohdsi.usagi.ui.actions.ApproveAction;
-import org.ohdsi.usagi.ui.actions.ApproveAllAction;
-import org.ohdsi.usagi.ui.actions.ClearAllAction;
-import org.ohdsi.usagi.ui.actions.ConceptInformationAction;
-import org.ohdsi.usagi.ui.actions.ExitAction;
-import org.ohdsi.usagi.ui.actions.ExportForReviewAction;
-import org.ohdsi.usagi.ui.actions.ExportSourceToConceptMapAction;
-import org.ohdsi.usagi.ui.actions.ImportAction;
-import org.ohdsi.usagi.ui.actions.OpenAction;
-import org.ohdsi.usagi.ui.actions.RebuildIndexAction;
-import org.ohdsi.usagi.ui.actions.SaveAction;
-import org.ohdsi.usagi.ui.actions.SaveAsAction;
-import org.ohdsi.usagi.ui.actions.ShowStatsAction;
+import org.ohdsi.usagi.ui.actions.*;
 
 public class Global {
 	public static JFrame							frame;
@@ -57,6 +43,8 @@ public class Global {
 	public static ApproveAllAction					approveAllAction;
 	public static ClearAllAction					clearAllAction;
 	public static ConceptInformationAction			conceptInfoAction;
+	public static AthenaAction						athenaAction;
+	public static GoogleSearchAction				googleSearchAction;
 	public static AboutAction						aboutAction;
 	public static ExportSourceToConceptMapAction	exportAction;
 	public static ExportForReviewAction				exportForReviewAction;

--- a/src/org/ohdsi/usagi/ui/Mapping.java
+++ b/src/org/ohdsi/usagi/ui/Mapping.java
@@ -32,14 +32,21 @@ public class Mapping extends ArrayList<CodeMapping> {
 
 	public void loadFromFile(String filename) {
 		clear();
-		boolean invalidTargets = false;
+		int nInvalidTargets = 0;
 		for (CodeMapping codeMapping : new ReadCodeMappingsFromFile(filename)) {
 			add(codeMapping);
-			if (codeMapping.mappingStatus == CodeMapping.MappingStatus.INVALID_TARGET)
-				invalidTargets = true;
+			if (codeMapping.mappingStatus == CodeMapping.MappingStatus.INVALID_TARGET) {
+				nInvalidTargets += 1;
+			}
 		}
-		if (invalidTargets)
-			JOptionPane.showMessageDialog(null, "Illegal target concepts found. The corresponding source codes are marked in red.", "Illegal target concepts", JOptionPane.WARNING_MESSAGE);
+		if (nInvalidTargets > 0) {
+			JOptionPane.showMessageDialog(
+					null,
+					nInvalidTargets + " illegal target concepts found. The corresponding source codes are marked in red.",
+					"Illegal target concepts",
+					JOptionPane.WARNING_MESSAGE
+			);
+		}
 		fireDataChanged(DataChangeListener.RESTRUCTURE_EVENT);
 	}
 

--- a/src/org/ohdsi/usagi/ui/MappingDetailPanel.java
+++ b/src/org/ohdsi/usagi/ui/MappingDetailPanel.java
@@ -76,6 +76,7 @@ public class MappingDetailPanel extends JPanel implements CodeSelectedListener, 
 	private JRadioButton						manualQueryButton;
 	private JTextField							manualQueryField;
 	private CodeMapping							codeMapping;
+	private List<CodeMapping> 					codeMappingsFromMulti;
 	private FilterPanel							filterPanel;
 	private Timer								timer;
 
@@ -86,6 +87,7 @@ public class MappingDetailPanel extends JPanel implements CodeSelectedListener, 
 		add(createTargetConceptsPanel());
 		add(createSearchPanel());
 		add(createApprovePanel());
+		codeMappingsFromMulti = new ArrayList<>();
 	}
 
 	private Component createSearchPanel() {
@@ -373,6 +375,16 @@ public class MappingDetailPanel extends JPanel implements CodeSelectedListener, 
 		doSearch();
 	}
 
+	@Override
+	public void addCodeMultiSelected(CodeMapping codeMapping) {
+		this.codeMappingsFromMulti.add(codeMapping);
+	}
+
+	@Override
+	public void clearCodeMultiSelected() {
+		this.codeMappingsFromMulti = new ArrayList<>();
+	}
+
 	public void approve() {
 		if (codeMapping.mappingStatus != CodeMapping.MappingStatus.APPROVED) {
 			codeMapping.mappingStatus = CodeMapping.MappingStatus.APPROVED;
@@ -398,12 +410,23 @@ public class MappingDetailPanel extends JPanel implements CodeSelectedListener, 
 
 	public void addConcept(Concept concept) {
 		codeMapping.targetConcepts.add(concept);
+		for (CodeMapping codeMappingMulti : codeMappingsFromMulti) {
+			codeMappingMulti.targetConcepts.add(concept);
+		}
 		targetConceptTableModel.fireTableDataChanged();
-		Global.mapping.fireDataChanged(DataChangeListener.SIMPLE_UPDATE_EVENT);
+
+		if (codeMappingsFromMulti.size() > 0) {
+			Global.mapping.fireDataChanged(DataChangeListener.MULTI_UPDATE_EVENT);
+		} else {
+			Global.mapping.fireDataChanged(DataChangeListener.SIMPLE_UPDATE_EVENT);
+		}
 	}
 
 	public void replaceConcepts(Concept concept) {
 		codeMapping.targetConcepts.clear();
+		for (CodeMapping codeMappingMulti : codeMappingsFromMulti) {
+			codeMappingMulti.targetConcepts.clear();
+		}
 		addConcept(concept);
 	}
 

--- a/src/org/ohdsi/usagi/ui/MappingDetailPanel.java
+++ b/src/org/ohdsi/usagi/ui/MappingDetailPanel.java
@@ -199,21 +199,21 @@ public class MappingDetailPanel extends JPanel implements CodeSelectedListener, 
 		searchTable.setPreferredScrollableViewportSize(new Dimension(100, 100));
 		searchTable.setAutoResizeMode(JTable.AUTO_RESIZE_ALL_COLUMNS);
 		searchTable.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
-		searchTable.getSelectionModel().addListSelectionListener(new ListSelectionListener() {
-			public void valueChanged(ListSelectionEvent event) {
-				int viewRow = searchTable.getSelectedRow();
-				if (viewRow == -1) {
-					addButton.setEnabled(false);
-					replaceButton.setEnabled(false);
-				} else {
-					addButton.setEnabled(true);
-					replaceButton.setEnabled(true);
-					Global.conceptInfoAction.setEnabled(true);
-					int modelRow = searchTable.convertRowIndexToModel(viewRow);
-					Global.conceptInformationDialog.setConcept(searchTableModel.getConcept(modelRow));
-				}
+		searchTable.getSelectionModel().addListSelectionListener(event -> {
+			int viewRow = searchTable.getSelectedRow();
+			if (viewRow == -1) {
+				addButton.setEnabled(false);
+				replaceButton.setEnabled(false);
+			} else {
+				addButton.setEnabled(true);
+				replaceButton.setEnabled(true);
+				int modelRow = searchTable.convertRowIndexToModel(viewRow);
+				Global.conceptInfoAction.setEnabled(true);
+				Global.conceptInformationDialog.setConcept(searchTableModel.getConcept(modelRow));
+				Global.athenaAction.setEnabled(true);
+				Global.athenaAction.setConcept(searchTableModel.getConcept(modelRow));
+				Global.googleSearchAction.setEnabled(false);
 			}
-
 		});
 		// searchTable.hideColumn("Synonym");
 		searchTable.hideColumn("Valid start date");
@@ -321,19 +321,19 @@ public class MappingDetailPanel extends JPanel implements CodeSelectedListener, 
 		targetConceptTable.setPreferredScrollableViewportSize(new Dimension(500, 45));
 		targetConceptTable.setAutoResizeMode(JTable.AUTO_RESIZE_ALL_COLUMNS);
 		targetConceptTable.setRowSelectionAllowed(true);
-		targetConceptTable.getSelectionModel().addListSelectionListener(new ListSelectionListener() {
-			public void valueChanged(ListSelectionEvent event) {
-				int viewRow = targetConceptTable.getSelectedRow();
-				if (viewRow == -1) {
-					removeButton.setEnabled(false);
-				} else {
-					removeButton.setEnabled(true);
-					Global.conceptInfoAction.setEnabled(true);
-					int modelRow = targetConceptTable.convertRowIndexToModel(viewRow);
-					Global.conceptInformationDialog.setConcept(targetConceptTableModel.getConcept(modelRow));
-				}
+		targetConceptTable.getSelectionModel().addListSelectionListener(event -> {
+			int viewRow = targetConceptTable.getSelectedRow();
+			if (viewRow == -1) {
+				removeButton.setEnabled(false);
+			} else {
+				removeButton.setEnabled(true);
+				int modelRow = targetConceptTable.convertRowIndexToModel(viewRow);
+				Global.conceptInfoAction.setEnabled(true);
+				Global.conceptInformationDialog.setConcept(targetConceptTableModel.getConcept(modelRow));
+				Global.athenaAction.setEnabled(true);
+				Global.athenaAction.setConcept(targetConceptTableModel.getConcept(modelRow));
+				Global.googleSearchAction.setEnabled(false);
 			}
-
 		});
 		targetConceptTable.hideColumn("Valid start date");
 		targetConceptTable.hideColumn("Valid end date");

--- a/src/org/ohdsi/usagi/ui/MappingTablePanel.java
+++ b/src/org/ohdsi/usagi/ui/MappingTablePanel.java
@@ -52,26 +52,32 @@ public class MappingTablePanel extends JPanel implements DataChangeListener {
 		table.setPreferredScrollableViewportSize(new Dimension(1200, 200));
 		table.setSelectionMode(ListSelectionModel.MULTIPLE_INTERVAL_SELECTION);
 
-		table.getSelectionModel().addListSelectionListener(new ListSelectionListener() {
-			public void valueChanged(ListSelectionEvent event) {
-				if (!ignoreSelection) {
-					int viewRow = table.getSelectedRow();
-					if (viewRow != -1) {
-						int modelRow = table.convertRowIndexToModel(viewRow);
-						for (CodeSelectedListener listener : listeners)
-							listener.codeSelected(tableModel.getCodeMapping(modelRow));
-						Global.approveAction.setEnabled(true);
-						Global.approveAllAction.setEnabled(true);
-						Global.clearAllAction.setEnabled(true);
-						if (tableModel.getCodeMapping(modelRow).targetConcepts.size() > 0) {
-							Global.conceptInfoAction.setEnabled(true);
-							Global.conceptInformationDialog.setConcept(tableModel.getCodeMapping(modelRow).targetConcepts.get(0));
-						}
-					} else {
-						Global.approveAllAction.setEnabled(false);
-						Global.approveAction.setEnabled(false);
-						Global.clearAllAction.setEnabled(false);
+		table.getSelectionModel().addListSelectionListener(event -> {
+			if (!ignoreSelection) {
+				int viewRow = table.getSelectedRow();
+				if (viewRow != -1) {
+					int modelRow = table.convertRowIndexToModel(viewRow);
+					for (CodeSelectedListener listener : listeners) {
+						listener.codeSelected(tableModel.getCodeMapping(modelRow));
 					}
+
+					Global.googleSearchAction.setEnabled(true);
+					Global.googleSearchAction.setSourceTerm(tableModel.getCodeMapping(modelRow).sourceCode.sourceName);
+
+					Global.approveAction.setEnabled(true);
+					Global.approveAllAction.setEnabled(true);
+					Global.clearAllAction.setEnabled(true);
+					if (tableModel.getCodeMapping(modelRow).targetConcepts.size() > 0) {
+						Concept firstConcept = tableModel.getCodeMapping(modelRow).targetConcepts.get(0);
+						Global.conceptInfoAction.setEnabled(true);
+						Global.conceptInformationDialog.setConcept(firstConcept);
+						Global.athenaAction.setEnabled(true);
+						Global.athenaAction.setConcept(firstConcept);
+					}
+				} else {
+					Global.approveAllAction.setEnabled(false);
+					Global.approveAction.setEnabled(false);
+					Global.clearAllAction.setEnabled(false);
 				}
 			}
 		});

--- a/src/org/ohdsi/usagi/ui/RebuildIndexDialog.java
+++ b/src/org/ohdsi/usagi/ui/RebuildIndexDialog.java
@@ -58,13 +58,12 @@ public class RebuildIndexDialog extends JDialog {
 	private void buildIndex() {
 		String vocabFolder = vocabFolderField.getText();
 		String loincFile = loincFileField.getText();
-		if (!(new File(vocabFolder + "/CONCEPT.csv").exists())) {
-			JOptionPane.showMessageDialog(this, "Vocabulary file CONCEPT.csv not found", "Cannot build index", JOptionPane.ERROR_MESSAGE);
-			return;
-		}
-		if (!(new File(vocabFolder + "/CONCEPT_SYNONYM.csv").exists())) {
-			JOptionPane.showMessageDialog(this, "Vocabulary file CONCEPT_SYNONYM.csv not found", "Cannot build index", JOptionPane.ERROR_MESSAGE);
-			return;
+		String[] requiredVocabularyFiles = {"/CONCEPT.csv", "/CONCEPT_SYNONYM.csv", "/VOCABULARY.csv", "/CONCEPT_RELATIONSHIP.csv"};
+		for (String vocabFileName : requiredVocabularyFiles) {
+			if (!(new File(vocabFolder + vocabFileName).exists())) {
+				JOptionPane.showMessageDialog(this, "Vocabulary file " + vocabFileName + " not found", "Cannot build index", JOptionPane.ERROR_MESSAGE);
+				return;
+			}
 		}
 		if (loincCheckBox.isSelected() && !(new File(loincFile).exists())) {
 			JOptionPane.showMessageDialog(this, "LOINC file loinc.csv not found", "Cannot build index", JOptionPane.ERROR_MESSAGE);

--- a/src/org/ohdsi/usagi/ui/ShowStatsDialog.java
+++ b/src/org/ohdsi/usagi/ui/ShowStatsDialog.java
@@ -38,12 +38,6 @@ public class ShowStatsDialog extends JDialog {
 	private static final long	serialVersionUID	= 2028328868610404663L;
 
 	public ShowStatsDialog() {
-		String versionFileName = Global.folder + "/vocabularyVersion.txt";
-		String version = "Unknown";
-		if (new File(versionFileName).exists()) {
-			for (String line : new ReadTextFile(versionFileName))
-			  version = line;
-		} 
 		int termCount = Global.usagiSearchEngine.getTermCount();
 		BerkeleyDbStats berkeleyDbStats = Global.dbEngine.getStats();
 		NumberFormat numberFormat = NumberFormat.getNumberInstance(Locale.US);
@@ -62,7 +56,7 @@ public class ShowStatsDialog extends JDialog {
 		
 		g.gridx = 1;
 		g.gridy = 0;
-		add(new JLabel(version), g);
+		add(new JLabel(Global.vocabularyVersion), g);
 
 		g.gridx = 0;
 		g.gridy = 1;

--- a/src/org/ohdsi/usagi/ui/UsagiMain.java
+++ b/src/org/ohdsi/usagi/ui/UsagiMain.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
  * Copyright 2019 Observational Health Data Sciences and Informatics
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -28,27 +28,11 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.swing.JFrame;
-import javax.swing.JPanel;
-import javax.swing.JSplitPane;
+import javax.swing.*;
 
 import org.ohdsi.usagi.BerkeleyDbEngine;
 import org.ohdsi.usagi.UsagiSearchEngine;
-import org.ohdsi.usagi.ui.actions.AboutAction;
-import org.ohdsi.usagi.ui.actions.ApplyPreviousMappingAction;
-import org.ohdsi.usagi.ui.actions.ApproveAction;
-import org.ohdsi.usagi.ui.actions.ApproveAllAction;
-import org.ohdsi.usagi.ui.actions.ClearAllAction;
-import org.ohdsi.usagi.ui.actions.ConceptInformationAction;
-import org.ohdsi.usagi.ui.actions.ExitAction;
-import org.ohdsi.usagi.ui.actions.ExportForReviewAction;
-import org.ohdsi.usagi.ui.actions.ExportSourceToConceptMapAction;
-import org.ohdsi.usagi.ui.actions.ImportAction;
-import org.ohdsi.usagi.ui.actions.OpenAction;
-import org.ohdsi.usagi.ui.actions.RebuildIndexAction;
-import org.ohdsi.usagi.ui.actions.SaveAction;
-import org.ohdsi.usagi.ui.actions.SaveAsAction;
-import org.ohdsi.usagi.ui.actions.ShowStatsAction;
+import org.ohdsi.usagi.ui.actions.*;
 import org.ohdsi.utilities.files.ReadTextFile;
 
 /**
@@ -56,22 +40,16 @@ import org.ohdsi.utilities.files.ReadTextFile;
  */
 public class UsagiMain implements ActionListener {
 
-	private JFrame	frame;
-
 	public static void main(String[] args) {
 		new UsagiMain(args);
 	}
 
 	public UsagiMain(String[] args) {
-		frame = new JFrame("Usagi");
+		JFrame frame = new JFrame("Usagi");
 
 		// Initialize global variables:
 		Global.mapping = new Mapping();
-		if (args.length != 0)
-			Global.folder = args[0];
-		else
-			Global.folder = new File("").getAbsolutePath();
-
+		Global.folder = new File("").getAbsolutePath();
 		Global.usagiSearchEngine = new UsagiSearchEngine(Global.folder);
 		Global.dbEngine = new BerkeleyDbEngine(Global.folder);
 		if (Global.usagiSearchEngine.mainIndexExists()) {
@@ -107,10 +85,13 @@ public class UsagiMain implements ActionListener {
 		Global.clearAllAction.setEnabled(false);
 		Global.conceptInfoAction.setEnabled(false);
 
+		frame.setDefaultCloseOperation(JFrame.DO_NOTHING_ON_CLOSE);
 		frame.addWindowListener(new WindowAdapter() {
 			public void windowClosing(WindowEvent e) {
-				Global.dbEngine.shutdown();
-				System.exit(0);
+				if (UsagiDialogs.askBeforeExit()) {
+					Global.dbEngine.shutdown();
+					System.exit(0);
+				}
 			}
 		});
 		frame.setLayout(new BorderLayout());
@@ -139,6 +120,12 @@ public class UsagiMain implements ActionListener {
 
 		if (!Global.usagiSearchEngine.mainIndexExists())
 			Global.rebuildIndexAction.actionPerformed(null);
+
+		if (args.length == 1) {
+			Global.folder = args[0];
+		} else if (args.length > 1 && args[0].equals("--file")) {
+			OpenAction.open(new File(args[1]));
+		}
 	}
 
 	private String loadVocabularyVersion(String folder) {
@@ -147,7 +134,7 @@ public class UsagiMain implements ActionListener {
 		if (new File(versionFileName).exists()) {
 			for (String line : new ReadTextFile(versionFileName))
 				version = line;
-		} 
+		}
 		return version;
 	}
 

--- a/src/org/ohdsi/usagi/ui/UsagiMain.java
+++ b/src/org/ohdsi/usagi/ui/UsagiMain.java
@@ -49,7 +49,11 @@ public class UsagiMain implements ActionListener {
 
 		// Initialize global variables:
 		Global.mapping = new Mapping();
-		Global.folder = new File("").getAbsolutePath();
+		if (args.length == 1) {
+			Global.folder = args[0];
+		} else {
+			Global.folder = new File("").getAbsolutePath();
+		}
 		Global.usagiSearchEngine = new UsagiSearchEngine(Global.folder);
 		Global.dbEngine = new BerkeleyDbEngine(Global.folder);
 		if (Global.usagiSearchEngine.mainIndexExists()) {
@@ -121,9 +125,7 @@ public class UsagiMain implements ActionListener {
 		if (!Global.usagiSearchEngine.mainIndexExists())
 			Global.rebuildIndexAction.actionPerformed(null);
 
-		if (args.length == 1) {
-			Global.folder = args[0];
-		} else if (args.length > 1 && args[0].equals("--file")) {
+		if (args.length > 1 && args[0].equals("--file")) {
 			OpenAction.open(new File(args[1]));
 		}
 	}

--- a/src/org/ohdsi/usagi/ui/UsagiMain.java
+++ b/src/org/ohdsi/usagi/ui/UsagiMain.java
@@ -40,12 +40,14 @@ import org.ohdsi.utilities.files.ReadTextFile;
  */
 public class UsagiMain implements ActionListener {
 
+	public static String version = "1.2.9-SNAPSHOT";
+
 	public static void main(String[] args) {
 		new UsagiMain(args);
 	}
 
 	public UsagiMain(String[] args) {
-		JFrame frame = new JFrame("Usagi");
+		JFrame frame = new JFrame("Usagi v" + UsagiMain.version);
 
 		// Initialize global variables:
 		Global.mapping = new Mapping();
@@ -72,6 +74,8 @@ public class UsagiMain implements ActionListener {
 		Global.saveAsAction = new SaveAsAction();
 		Global.approveAction = new ApproveAction();
 		Global.conceptInfoAction = new ConceptInformationAction();
+		Global.athenaAction = new AthenaAction();
+		Global.googleSearchAction = new GoogleSearchAction();
 		Global.showStatsAction = new ShowStatsAction();
 		Global.aboutAction = new AboutAction();
 		Global.approveAllAction = new ApproveAllAction();
@@ -88,6 +92,8 @@ public class UsagiMain implements ActionListener {
 		Global.clearAllAction = new ClearAllAction();
 		Global.clearAllAction.setEnabled(false);
 		Global.conceptInfoAction.setEnabled(false);
+		Global.athenaAction.setEnabled(false);
+		Global.googleSearchAction.setEnabled(false);
 
 		frame.setDefaultCloseOperation(JFrame.DO_NOTHING_ON_CLOSE);
 		frame.addWindowListener(new WindowAdapter() {

--- a/src/org/ohdsi/usagi/ui/UsagiMenubar.java
+++ b/src/org/ohdsi/usagi/ui/UsagiMenubar.java
@@ -25,7 +25,7 @@ public class UsagiMenubar extends JMenuBar {
 
 	public UsagiMenubar() {
 		JMenu fileMenu = new JMenu("File");
-		fileMenu.setMnemonic(new Integer(KeyEvent.VK_F));
+		fileMenu.setMnemonic(KeyEvent.VK_F);
 		add(fileMenu);
 
 		fileMenu.add(Global.openAction);
@@ -38,7 +38,7 @@ public class UsagiMenubar extends JMenuBar {
 		fileMenu.add(Global.exitAction);
 
 		JMenu editMenu = new JMenu("Edit");
-		editMenu.setMnemonic(new Integer(KeyEvent.VK_E));
+		editMenu.setMnemonic(KeyEvent.VK_E);
 		add(editMenu);
 
 		editMenu.add(Global.approveAction);
@@ -46,13 +46,15 @@ public class UsagiMenubar extends JMenuBar {
 		editMenu.add(Global.clearAllAction);
 
 		JMenu viewMenu = new JMenu("View");
-		viewMenu.setMnemonic(new Integer(KeyEvent.VK_V));
+		viewMenu.setMnemonic(KeyEvent.VK_V);
 		add(viewMenu);
 
 		viewMenu.add(Global.conceptInfoAction);
+		viewMenu.add(Global.athenaAction);
+		viewMenu.add(Global.googleSearchAction);
 
 		JMenu helpMenu = new JMenu("Help");
-		helpMenu.setMnemonic(new Integer(KeyEvent.VK_H));
+		helpMenu.setMnemonic(KeyEvent.VK_H);
 		add(helpMenu);
 
 		helpMenu.add(Global.rebuildIndexAction);

--- a/src/org/ohdsi/usagi/ui/actions/AboutAction.java
+++ b/src/org/ohdsi/usagi/ui/actions/AboutAction.java
@@ -23,13 +23,14 @@ import javax.swing.Action;
 
 import org.ohdsi.usagi.ui.AboutDialog;
 import org.ohdsi.usagi.ui.Global;
+import org.ohdsi.usagi.ui.UsagiMain;
 
 public class AboutAction extends AbstractAction {
 
 	private static final long	serialVersionUID	= -6399524936473823131L;
 
 	public AboutAction() {
-		putValue(Action.NAME, "About Usagi");
+		putValue(Action.NAME, "About Usagi v" + UsagiMain.version);
 		putValue(Action.SHORT_DESCRIPTION, "About Usagi");
 		putValue(Action.MNEMONIC_KEY, KeyEvent.VK_A);
 	}

--- a/src/org/ohdsi/usagi/ui/actions/AboutAction.java
+++ b/src/org/ohdsi/usagi/ui/actions/AboutAction.java
@@ -31,7 +31,7 @@ public class AboutAction extends AbstractAction {
 	public AboutAction() {
 		putValue(Action.NAME, "About Usagi");
 		putValue(Action.SHORT_DESCRIPTION, "About Usagi");
-		putValue(Action.MNEMONIC_KEY, new Integer(KeyEvent.VK_A));
+		putValue(Action.MNEMONIC_KEY, KeyEvent.VK_A);
 	}
 
 	@Override

--- a/src/org/ohdsi/usagi/ui/actions/ApplyPreviousMappingAction.java
+++ b/src/org/ohdsi/usagi/ui/actions/ApplyPreviousMappingAction.java
@@ -28,6 +28,7 @@ import javax.swing.filechooser.FileFilter;
 import javax.swing.filechooser.FileNameExtensionFilter;
 
 import org.ohdsi.usagi.CodeMapping;
+import org.ohdsi.usagi.ui.DataChangeListener;
 import org.ohdsi.usagi.ui.Global;
 import org.ohdsi.usagi.ui.Mapping;
 
@@ -79,6 +80,7 @@ public class ApplyPreviousMappingAction extends AbstractAction {
 					+ " were applied to the current mapping and " + mappingsAdded + " were newly added.";
 			Global.mappingTablePanel.updateUI();
 			Global.mappingDetailPanel.updateUI();
+			Global.mapping.fireDataChanged(DataChangeListener.APPROVE_EVENT); // To update the footer
 			if (mappingsAdded > 0) {
 				Global.usagiSearchEngine.close();
 				Global.usagiSearchEngine.createDerivedIndex(Global.mapping.getSourceCodes(), Global.frame);

--- a/src/org/ohdsi/usagi/ui/actions/ApproveAction.java
+++ b/src/org/ohdsi/usagi/ui/actions/ApproveAction.java
@@ -31,7 +31,7 @@ public class ApproveAction extends AbstractAction {
 	public ApproveAction() {
 		putValue(Action.NAME, "Approve");
 		putValue(Action.SHORT_DESCRIPTION, "Approve the selected single mapping");
-		putValue(Action.MNEMONIC_KEY, new Integer(KeyEvent.VK_A));
+		putValue(Action.MNEMONIC_KEY, KeyEvent.VK_A);
 		putValue(Action.ACCELERATOR_KEY, KeyStroke.getKeyStroke(KeyEvent.VK_A, ActionEvent.ALT_MASK));
 	}
 

--- a/src/org/ohdsi/usagi/ui/actions/ApproveAllAction.java
+++ b/src/org/ohdsi/usagi/ui/actions/ApproveAllAction.java
@@ -16,9 +16,10 @@
 package org.ohdsi.usagi.ui.actions;
 
 import java.awt.event.ActionEvent;
+import java.awt.event.InputEvent;
+import java.awt.event.KeyEvent;
 
-import javax.swing.AbstractAction;
-import javax.swing.Action;
+import javax.swing.*;
 
 import org.ohdsi.usagi.ui.Global;
 
@@ -29,6 +30,7 @@ public class ApproveAllAction extends AbstractAction {
 	public ApproveAllAction() {
 		putValue(Action.NAME, "Approve selected");
 		putValue(Action.SHORT_DESCRIPTION, "Approve all selected mappings");
+		putValue(Action.ACCELERATOR_KEY, KeyStroke.getKeyStroke(KeyEvent.VK_A, InputEvent.ALT_MASK | InputEvent.SHIFT_DOWN_MASK));
 	}
 
 	@Override

--- a/src/org/ohdsi/usagi/ui/actions/AthenaAction.java
+++ b/src/org/ohdsi/usagi/ui/actions/AthenaAction.java
@@ -1,0 +1,58 @@
+/*******************************************************************************
+ * Copyright 2019 Observational Health Data Sciences and Informatics
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+package org.ohdsi.usagi.ui.actions;
+
+import org.ohdsi.usagi.Concept;
+import org.ohdsi.usagi.ui.AboutDialog;
+import org.ohdsi.usagi.ui.Global;
+import org.ohdsi.usagi.ui.UsagiMain;
+
+import javax.swing.*;
+import java.awt.*;
+import java.awt.event.ActionEvent;
+import java.awt.event.InputEvent;
+import java.awt.event.KeyEvent;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+
+public class AthenaAction extends AbstractAction {
+
+	private static final long serialVersionUID = -25905854723973L;
+	private static final String ATHENA_URL = "https://athena.ohdsi.org/search-terms/terms/";
+	private Concept selectedConcept;
+
+	public AthenaAction() {
+		putValue(Action.NAME, "Athena (web)");
+		putValue(Action.SHORT_DESCRIPTION, "Link out to Athena web based concept browser, showing page of currently selected OMOP concept.");
+		putValue(Action.MNEMONIC_KEY, KeyEvent.VK_W);
+		putValue(Action.ACCELERATOR_KEY, KeyStroke.getKeyStroke(KeyEvent.VK_W, InputEvent.ALT_MASK));
+	}
+
+	@Override
+	public void actionPerformed(ActionEvent arg0) {
+		try {
+			Desktop desktop = Desktop.getDesktop();
+			desktop.browse(new URI(ATHENA_URL + selectedConcept.conceptId));
+		} catch (URISyntaxException | IOException ex) {
+
+		}
+	}
+
+	public void setConcept(Concept concept) {
+		selectedConcept = concept;
+	}
+}

--- a/src/org/ohdsi/usagi/ui/actions/ConceptInformationAction.java
+++ b/src/org/ohdsi/usagi/ui/actions/ConceptInformationAction.java
@@ -31,7 +31,7 @@ public class ConceptInformationAction extends AbstractAction {
 	public ConceptInformationAction() {
 		putValue(Action.NAME, "Concept information");
 		putValue(Action.SHORT_DESCRIPTION, "Show additional concept information");
-		putValue(Action.MNEMONIC_KEY, new Integer(KeyEvent.VK_C));
+		putValue(Action.MNEMONIC_KEY, KeyEvent.VK_C);
 		putValue(Action.ACCELERATOR_KEY, KeyStroke.getKeyStroke(KeyEvent.VK_C, ActionEvent.ALT_MASK));
 	}
 

--- a/src/org/ohdsi/usagi/ui/actions/ExitAction.java
+++ b/src/org/ohdsi/usagi/ui/actions/ExitAction.java
@@ -15,10 +15,11 @@
  ******************************************************************************/
 package org.ohdsi.usagi.ui.actions;
 
+import org.ohdsi.usagi.ui.Global;
+
 import java.awt.event.ActionEvent;
 
-import javax.swing.AbstractAction;
-import javax.swing.Action;
+import javax.swing.*;
 
 public class ExitAction extends AbstractAction {
 
@@ -31,7 +32,10 @@ public class ExitAction extends AbstractAction {
 
 	@Override
 	public void actionPerformed(ActionEvent arg0) {
-		System.exit(0);
+		if (UsagiDialogs.askBeforeExit()) {
+			Global.dbEngine.shutdown();
+			System.exit(0);
+		}
 	}
 
 }

--- a/src/org/ohdsi/usagi/ui/actions/ExportForReviewAction.java
+++ b/src/org/ohdsi/usagi/ui/actions/ExportForReviewAction.java
@@ -46,6 +46,11 @@ public class ExportForReviewAction extends AbstractAction {
 
 	@Override
 	public void actionPerformed(ActionEvent arg0) {
+		if (Global.mapping.size() == 0) {
+			UsagiDialogs.warningNothingToExport();
+			return;
+		}
+
 		boolean exportUnapproved = UsagiDialogs.askExportUnapprovedMappings();
 
 		boolean hasApprovedMappings = false;
@@ -57,7 +62,7 @@ public class ExportForReviewAction extends AbstractAction {
 		}
 
 		if (!exportUnapproved && !hasApprovedMappings) {
-			UsagiDialogs.warningNothingToExport();
+			UsagiDialogs.warningNoApprovedToExport();
 			return;
 		}
 

--- a/src/org/ohdsi/usagi/ui/actions/ExportForReviewAction.java
+++ b/src/org/ohdsi/usagi/ui/actions/ExportForReviewAction.java
@@ -58,6 +58,7 @@ public class ExportForReviewAction extends AbstractAction {
 			fileChooser.setFileFilter(csvFilter);
 			if (fileChooser.showSaveDialog(Global.frame) == JFileChooser.APPROVE_OPTION) {
 				File file = fileChooser.getSelectedFile();
+				Global.folder = file.getParentFile().getAbsolutePath();
 				if (!file.getName().toLowerCase().endsWith(".csv"))
 					file = new File(file.getAbsolutePath() + ".csv");
 				Global.frame.setCursor(Cursor.getPredefinedCursor(Cursor.WAIT_CURSOR));

--- a/src/org/ohdsi/usagi/ui/actions/ExportSourceToConceptMapAction.java
+++ b/src/org/ohdsi/usagi/ui/actions/ExportSourceToConceptMapAction.java
@@ -15,12 +15,11 @@
  ******************************************************************************/
 package org.ohdsi.usagi.ui.actions;
 
+import java.awt.*;
 import java.awt.event.ActionEvent;
 import java.awt.event.KeyEvent;
 
-import javax.swing.AbstractAction;
-import javax.swing.Action;
-import javax.swing.JOptionPane;
+import javax.swing.*;
 
 import org.ohdsi.usagi.CodeMapping;
 import org.ohdsi.usagi.CodeMapping.MappingStatus;
@@ -34,23 +33,30 @@ public class ExportSourceToConceptMapAction extends AbstractAction {
 	public ExportSourceToConceptMapAction() {
 		putValue(Action.NAME, "Export source_to_concept_map");
 		putValue(Action.SHORT_DESCRIPTION, "Export mapping to source_to_concept_map");
-		putValue(Action.MNEMONIC_KEY, new Integer(KeyEvent.VK_E));
+		putValue(Action.MNEMONIC_KEY, KeyEvent.VK_E);
+		putValue(Action.ACCELERATOR_KEY, KeyStroke.getKeyStroke(KeyEvent.VK_E, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask()));
 	}
 
 	@Override
 	public void actionPerformed(ActionEvent arg0) {
+		boolean exportUnapproved = UsagiDialogs.askExportUnapprovedMappings();
+
 		boolean hasApprovedMappings = false;
-		for (CodeMapping mapping : Global.mapping)
+		for (CodeMapping mapping : Global.mapping) {
 			if (mapping.mappingStatus == MappingStatus.APPROVED) {
 				hasApprovedMappings = true;
 				break;
 			}
-		if (hasApprovedMappings) {
-			ExportSourceToConceptMapDialog dialog = new ExportSourceToConceptMapDialog();
-			dialog.setVisible(true);
-		} else {
-			JOptionPane.showMessageDialog(Global.frame, "There are no approved mappings, so nothing to export", "Warning", JOptionPane.WARNING_MESSAGE);
 		}
+
+		if (!exportUnapproved && !hasApprovedMappings) {
+			UsagiDialogs.warningNothingToExport();
+			return;
+		}
+
+		ExportSourceToConceptMapDialog exportDialog = new ExportSourceToConceptMapDialog();
+		exportDialog.setExportUnapproved(exportUnapproved);
+		exportDialog.setVisible(true);
 	}
 
 }

--- a/src/org/ohdsi/usagi/ui/actions/ExportSourceToConceptMapAction.java
+++ b/src/org/ohdsi/usagi/ui/actions/ExportSourceToConceptMapAction.java
@@ -39,6 +39,11 @@ public class ExportSourceToConceptMapAction extends AbstractAction {
 
 	@Override
 	public void actionPerformed(ActionEvent arg0) {
+		if (Global.mapping.size() == 0) {
+			UsagiDialogs.warningNothingToExport();
+			return;
+		}
+
 		boolean exportUnapproved = UsagiDialogs.askExportUnapprovedMappings();
 
 		boolean hasApprovedMappings = false;
@@ -50,7 +55,7 @@ public class ExportSourceToConceptMapAction extends AbstractAction {
 		}
 
 		if (!exportUnapproved && !hasApprovedMappings) {
-			UsagiDialogs.warningNothingToExport();
+			UsagiDialogs.warningNoApprovedToExport();
 			return;
 		}
 

--- a/src/org/ohdsi/usagi/ui/actions/GoogleSearchAction.java
+++ b/src/org/ohdsi/usagi/ui/actions/GoogleSearchAction.java
@@ -15,30 +15,41 @@
  ******************************************************************************/
 package org.ohdsi.usagi.ui.actions;
 
+import org.ohdsi.usagi.Concept;
+
+import javax.swing.*;
+import java.awt.*;
 import java.awt.event.ActionEvent;
 import java.awt.event.InputEvent;
 import java.awt.event.KeyEvent;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
 
-import javax.swing.AbstractAction;
-import javax.swing.Action;
-import javax.swing.KeyStroke;
+public class GoogleSearchAction extends AbstractAction {
 
-import org.ohdsi.usagi.ui.Global;
+	private static final long serialVersionUID = -934859464521233L;
+	private static final String GOOGLE_Q_URL = "https://www.google.com/search?q=";
+	private String sourceTerm;
 
-public class ConceptInformationAction extends AbstractAction {
-
-	private static final long	serialVersionUID	= -1846753187468184738L;
-
-	public ConceptInformationAction() {
-		putValue(Action.NAME, "Concept information");
-		putValue(Action.SHORT_DESCRIPTION, "Show additional concept information");
-		putValue(Action.MNEMONIC_KEY, KeyEvent.VK_C);
-		putValue(Action.ACCELERATOR_KEY, KeyStroke.getKeyStroke(KeyEvent.VK_C, InputEvent.ALT_MASK));
+	public GoogleSearchAction() {
+		putValue(Action.NAME, "Google (web)");
+		putValue(Action.SHORT_DESCRIPTION, "Search source term on Google");
+		putValue(Action.MNEMONIC_KEY, KeyEvent.VK_G);
+		putValue(Action.ACCELERATOR_KEY, KeyStroke.getKeyStroke(KeyEvent.VK_G, InputEvent.ALT_MASK));
 	}
 
 	@Override
 	public void actionPerformed(ActionEvent arg0) {
-		Global.conceptInformationDialog.setVisible(true);
+		try {
+			Desktop desktop = Desktop.getDesktop();
+			desktop.browse(new URI(GOOGLE_Q_URL + sourceTerm));
+		} catch (URISyntaxException | IOException ex) {
+
+		}
 	}
 
+	public void setSourceTerm(String sourceTerm) {
+		this.sourceTerm = sourceTerm;
+	}
 }

--- a/src/org/ohdsi/usagi/ui/actions/ImportAction.java
+++ b/src/org/ohdsi/usagi/ui/actions/ImportAction.java
@@ -53,6 +53,7 @@ public class ImportAction extends AbstractAction {
 		fileChooser.setAcceptAllFileFilterUsed(false);
 		if (fileChooser.showOpenDialog(Global.frame) == JFileChooser.APPROVE_OPTION) {
 			File file = fileChooser.getSelectedFile();
+			Global.folder = file.getParentFile().getAbsolutePath();
 			new ImportDialog(file.getAbsolutePath());
 		}
 	}

--- a/src/org/ohdsi/usagi/ui/actions/ImportAction.java
+++ b/src/org/ohdsi/usagi/ui/actions/ImportAction.java
@@ -15,6 +15,7 @@
  ******************************************************************************/
 package org.ohdsi.usagi.ui.actions;
 
+import java.awt.*;
 import java.awt.event.ActionEvent;
 import java.awt.event.KeyEvent;
 import java.io.File;
@@ -36,8 +37,8 @@ public class ImportAction extends AbstractAction {
 	public ImportAction() {
 		putValue(Action.NAME, "Import codes");
 		putValue(Action.SHORT_DESCRIPTION, "Import a file containing codes");
-		putValue(Action.MNEMONIC_KEY, new Integer(KeyEvent.VK_I));
-		putValue(Action.ACCELERATOR_KEY, KeyStroke.getKeyStroke(KeyEvent.VK_I, ActionEvent.CTRL_MASK));
+		putValue(Action.MNEMONIC_KEY, KeyEvent.VK_I);
+		putValue(Action.ACCELERATOR_KEY, KeyStroke.getKeyStroke(KeyEvent.VK_I, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask()));
 	}
 
 	@Override

--- a/src/org/ohdsi/usagi/ui/actions/OpenAction.java
+++ b/src/org/ohdsi/usagi/ui/actions/OpenAction.java
@@ -15,6 +15,7 @@
  ******************************************************************************/
 package org.ohdsi.usagi.ui.actions;
 
+import java.awt.*;
 import java.awt.event.ActionEvent;
 import java.awt.event.KeyEvent;
 import java.io.File;
@@ -35,8 +36,8 @@ public class OpenAction extends AbstractAction {
 	public OpenAction() {
 		putValue(Action.NAME, "Open");
 		putValue(Action.SHORT_DESCRIPTION, "Open mapping file");
-		putValue(Action.MNEMONIC_KEY, new Integer(KeyEvent.VK_O));
-		putValue(Action.ACCELERATOR_KEY, KeyStroke.getKeyStroke(KeyEvent.VK_O, ActionEvent.CTRL_MASK));
+		putValue(Action.MNEMONIC_KEY, KeyEvent.VK_O);
+		putValue(Action.ACCELERATOR_KEY, KeyStroke.getKeyStroke(KeyEvent.VK_O, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask()));
 	}
 
 	@Override
@@ -46,19 +47,24 @@ public class OpenAction extends AbstractAction {
 		fileChooser.setFileFilter(csvFilter);
 		if (fileChooser.showOpenDialog(Global.frame) == JFileChooser.APPROVE_OPTION) {
 			File file = fileChooser.getSelectedFile();
-			Global.frame.setTitle("Usagi - " + file.getName());
-			Global.filename = file.getAbsolutePath();
-			Global.folder = file.getParentFile().getAbsolutePath();
-			Global.mapping.loadFromFile(Global.filename);
-			Global.usagiSearchEngine.close();
-			Global.usagiSearchEngine.createDerivedIndex(Global.mapping.getSourceCodes(), Global.frame);
-			Global.mappingDetailPanel.doSearch();
-			Global.applyPreviousMappingAction.setEnabled(true);
-			Global.saveAction.setEnabled(true);
-			Global.saveAsAction.setEnabled(true);
-			Global.exportAction.setEnabled(true);
-			Global.exportForReviewAction.setEnabled(true);
+			open(file);
 		}
+	}
+
+	public static void open(File file) {
+		String a  = file.getName();
+		Global.frame.setTitle("Usagi - " + file.getName());
+		Global.filename = file.getAbsolutePath();
+		Global.folder = file.getParentFile().getAbsolutePath();
+		Global.mapping.loadFromFile(Global.filename);
+		Global.usagiSearchEngine.close();
+		Global.usagiSearchEngine.createDerivedIndex(Global.mapping.getSourceCodes(), Global.frame);
+		Global.mappingDetailPanel.doSearch();
+		Global.applyPreviousMappingAction.setEnabled(true);
+		Global.saveAction.setEnabled(true);
+		Global.saveAsAction.setEnabled(true);
+		Global.exportAction.setEnabled(true);
+		Global.exportForReviewAction.setEnabled(true);
 	}
 
 }

--- a/src/org/ohdsi/usagi/ui/actions/OpenAction.java
+++ b/src/org/ohdsi/usagi/ui/actions/OpenAction.java
@@ -48,6 +48,7 @@ public class OpenAction extends AbstractAction {
 			File file = fileChooser.getSelectedFile();
 			Global.frame.setTitle("Usagi - " + file.getName());
 			Global.filename = file.getAbsolutePath();
+			Global.folder = file.getParentFile().getAbsolutePath();
 			Global.mapping.loadFromFile(Global.filename);
 			Global.usagiSearchEngine.close();
 			Global.usagiSearchEngine.createDerivedIndex(Global.mapping.getSourceCodes(), Global.frame);

--- a/src/org/ohdsi/usagi/ui/actions/OpenAction.java
+++ b/src/org/ohdsi/usagi/ui/actions/OpenAction.java
@@ -52,7 +52,6 @@ public class OpenAction extends AbstractAction {
 	}
 
 	public static void open(File file) {
-		String a  = file.getName();
 		Global.frame.setTitle("Usagi - " + file.getName());
 		Global.filename = file.getAbsolutePath();
 		Global.folder = file.getParentFile().getAbsolutePath();

--- a/src/org/ohdsi/usagi/ui/actions/RebuildIndexAction.java
+++ b/src/org/ohdsi/usagi/ui/actions/RebuildIndexAction.java
@@ -30,7 +30,7 @@ public class RebuildIndexAction extends AbstractAction {
 	public RebuildIndexAction() {
 		putValue(Action.NAME, "Rebuild index");
 		putValue(Action.SHORT_DESCRIPTION, "Rebuild the index from the vocabulary data files");
-		putValue(Action.MNEMONIC_KEY, new Integer(KeyEvent.VK_R));
+		putValue(Action.MNEMONIC_KEY, KeyEvent.VK_R);
 	}
 
 	@Override

--- a/src/org/ohdsi/usagi/ui/actions/SaveAction.java
+++ b/src/org/ohdsi/usagi/ui/actions/SaveAction.java
@@ -15,8 +15,9 @@
  ******************************************************************************/
 package org.ohdsi.usagi.ui.actions;
 
-import java.awt.Cursor;
+import java.awt.*;
 import java.awt.event.ActionEvent;
+import java.awt.event.InputEvent;
 import java.awt.event.KeyEvent;
 import java.io.File;
 
@@ -36,8 +37,8 @@ public class SaveAction extends AbstractAction {
 	public SaveAction() {
 		putValue(Action.NAME, "Save");
 		putValue(Action.SHORT_DESCRIPTION, "Save mapping file");
-		putValue(Action.MNEMONIC_KEY, new Integer(KeyEvent.VK_S));
-		putValue(Action.ACCELERATOR_KEY, KeyStroke.getKeyStroke(KeyEvent.VK_S, ActionEvent.CTRL_MASK));
+		putValue(Action.MNEMONIC_KEY, KeyEvent.VK_S);
+		putValue(Action.ACCELERATOR_KEY, KeyStroke.getKeyStroke(KeyEvent.VK_S, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask()));
 	}
 
 	@Override

--- a/src/org/ohdsi/usagi/ui/actions/SaveAction.java
+++ b/src/org/ohdsi/usagi/ui/actions/SaveAction.java
@@ -52,6 +52,7 @@ public class SaveAction extends AbstractAction {
 					file = new File(file.getAbsolutePath() + ".csv");
 				Global.frame.setTitle("Usagi - " + file.getName());
 				Global.filename = file.getAbsolutePath();
+				Global.folder = file.getParentFile().getAbsolutePath();
 			}
 		}
 		if (Global.filename != null) {

--- a/src/org/ohdsi/usagi/ui/actions/SaveAsAction.java
+++ b/src/org/ohdsi/usagi/ui/actions/SaveAsAction.java
@@ -47,6 +47,7 @@ public class SaveAsAction extends AbstractAction {
 				file = new File(file.getAbsolutePath() + ".csv");
 			Global.frame.setTitle("Usagi - " + file.getName());
 			Global.filename = file.getAbsolutePath();
+			Global.folder = file.getParentFile().getAbsolutePath();
 			Global.frame.setCursor(Cursor.getPredefinedCursor(Cursor.WAIT_CURSOR));
 			Global.mapping.saveToFile(Global.filename);
 			Global.frame.setCursor(Cursor.getPredefinedCursor(Cursor.DEFAULT_CURSOR));

--- a/src/org/ohdsi/usagi/ui/actions/ShowStatsAction.java
+++ b/src/org/ohdsi/usagi/ui/actions/ShowStatsAction.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
  * Copyright 2019 Observational Health Data Sciences and Informatics
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -31,7 +31,7 @@ public class ShowStatsAction extends AbstractAction {
 	public ShowStatsAction() {
 		putValue(Action.NAME, "Show index statistics");
 		putValue(Action.SHORT_DESCRIPTION, "Show index stats");
-		putValue(Action.MNEMONIC_KEY, new Integer(KeyEvent.VK_S));
+		putValue(Action.MNEMONIC_KEY, KeyEvent.VK_S);
 	}
 
 	@Override

--- a/src/org/ohdsi/usagi/ui/actions/UsagiDialogs.java
+++ b/src/org/ohdsi/usagi/ui/actions/UsagiDialogs.java
@@ -1,0 +1,45 @@
+package org.ohdsi.usagi.ui.actions;
+
+import org.ohdsi.usagi.ui.Global;
+
+import javax.swing.*;
+
+public class UsagiDialogs {
+    public static boolean askExportUnapprovedMappings() {
+        String[] options = {"Only approved","Approved and Unapproved"};
+        int PromptResult = JOptionPane.showOptionDialog(
+                Global.frame,
+                "Do you want to export both approved and unapproved mappings?",
+                "Export for review",
+                JOptionPane.YES_NO_OPTION,
+                JOptionPane.QUESTION_MESSAGE,
+                null,
+                options,
+                options[0]
+        );
+        return PromptResult == 1;
+    }
+
+    public static void warningNothingToExport() {
+        JOptionPane.showMessageDialog(
+                Global.frame,
+                "There are no approved mappings, so nothing to export",
+                "Nothing to export",
+                JOptionPane.WARNING_MESSAGE
+        );
+    }
+
+    public static boolean askBeforeExit() {
+        String[] objButtons = {"Yes","No"};
+        int PromptResult = JOptionPane.showOptionDialog(
+                Global.frame,
+                "Do you want to exit?\nPlease make sure that any work is saved",
+                "Usagi",
+                JOptionPane.DEFAULT_OPTION,
+                JOptionPane.WARNING_MESSAGE,
+                null, objButtons, objButtons[1]
+        );
+        return PromptResult == JOptionPane.YES_OPTION;
+    }
+
+}

--- a/src/org/ohdsi/usagi/ui/actions/UsagiDialogs.java
+++ b/src/org/ohdsi/usagi/ui/actions/UsagiDialogs.java
@@ -23,6 +23,15 @@ public class UsagiDialogs {
     public static void warningNothingToExport() {
         JOptionPane.showMessageDialog(
                 Global.frame,
+                "There are no mappings, so nothing to export",
+                "Nothing to export",
+                JOptionPane.WARNING_MESSAGE
+        );
+    }
+
+    public static void warningNoApprovedToExport() {
+        JOptionPane.showMessageDialog(
+                Global.frame,
                 "There are no approved mappings, so nothing to export",
                 "Nothing to export",
                 JOptionPane.WARNING_MESSAGE

--- a/src/org/ohdsi/utilities/files/WriteCSVFile.java
+++ b/src/org/ohdsi/utilities/files/WriteCSVFile.java
@@ -86,15 +86,17 @@ public class WriteCSVFile {
 		Iterator<String> iterator = columns.iterator();
 		while (iterator.hasNext()) {
 			String column = iterator.next();
-			boolean hasQuotes = column.contains("\"");
-			column = column.replaceAll("\\\\", "\\\\\\\\");
-			if (hasQuotes)
-				column = column.replaceAll("\"", "\\\\\"");
-			column = column.replaceAll("\r", "");
-			column = column.replaceAll("\n", "\\\\n");
-			if (hasQuotes || column.contains(Character.toString(delimiter)))
-				column = "\"" + column + "\"";
-			sb.append(column);
+			if (column != null) {
+				boolean hasQuotes = column.contains("\"");
+				column = column.replaceAll("\\\\", "\\\\\\\\");
+				if (hasQuotes)
+					column = column.replaceAll("\"", "\\\\\"");
+				column = column.replaceAll("\r", "");
+				column = column.replaceAll("\n", "\\\\n");
+				if (hasQuotes || column.contains(Character.toString(delimiter)))
+					column = "\"" + column + "\"";
+				sb.append(column);
+			}
 			if (iterator.hasNext())
 				sb.append(delimiter);
 		}


### PR DESCRIPTION
## Fixes
- Apply previous mapping #71 #45  #62 
- Save last folder #72 #65 
- Fix typo's #69 
- Multiple small refactorings
- Check for all needed vocabulary files before starting index (re)building #75 #70 

## Features
- Option to export unapproved mappings (source_to_concept_map AND review)
- If target_concept_id is 0, export vocabulary_id as 'None'.
- Use os specific menu shortcut key (ctrl for windows, cmd for mac)
- Ask before exiting