### PR TITLE
Google and Athena web links

### DIFF
--- a/src/org/ohdsi/usagi/ui/AboutDialog.java
+++ b/src/org/ohdsi/usagi/ui/AboutDialog.java
@@ -40,10 +40,9 @@ import javax.swing.event.HyperlinkListener;
 public class AboutDialog extends JDialog {
 
 	private static final long	serialVersionUID	= 2028328868610404663L;
-	private JEditorPane			text;
 
 	public AboutDialog() {
-		setTitle("About Usagi");
+		setTitle("About Usagi v" + UsagiMain.version);
 		setLayout(new GridBagLayout());
 
 		GridBagConstraints g = new GridBagConstraints();
@@ -60,9 +59,11 @@ public class AboutDialog extends JDialog {
 		g.gridx = 1;
 		g.gridy = 0;
 
-		text = new JEditorPane(
+		JEditorPane text = new JEditorPane(
 				"text/html",
-				"Usagi was developed by Martijn Schuemie in <a href=\"http://ohdsi.org\">Observational Health Data Sciences and Informatics</a> (OHDSI).<br/><br/>For help, please review the <a href =\"http://www.ohdsi.org/web/wiki/doku.php?id=documentation:software:usagi\">Usagi Wiki</a>.");
+				"Usagi was developed by Martijn Schuemie" +
+						"<br/>in <a href=\"http://ohdsi.org\">Observational Health Data Sciences and Informatics</a> (OHDSI)." +
+						"<br/><br/>For help, please review the <a href =\"http://www.ohdsi.org/web/wiki/doku.php?id=documentation:software:usagi\">Usagi Wiki</a>.");
 
 		text.setEditable(false);
 		text.setOpaque(false);

--- a/src/org/ohdsi/usagi/ui/ConceptTableModel.java
+++ b/src/org/ohdsi/usagi/ui/ConceptTableModel.java
@@ -130,7 +130,7 @@ class ConceptTableModel extends AbstractTableModel {
 	}
 
 	public boolean isCellEditable(int row, int col) {
-		return true;
+		return false;
 	}
 
 	public void setValueAt(Object value, int row, int col) {

--- a/src/org/ohdsi/usagi/ui/DataChangeListener.java
+++ b/src/org/ohdsi/usagi/ui/DataChangeListener.java
@@ -17,19 +17,19 @@ package org.ohdsi.usagi.ui;
 
 public interface DataChangeListener {
 
-	public static DataChangeEvent	APPROVE_EVENT		= new DataChangeEvent(true, false);
-	public static DataChangeEvent	SIMPLE_UPDATE_EVENT	= new DataChangeEvent(false, false);
-	public static DataChangeEvent	RESTRUCTURE_EVENT	= new DataChangeEvent(false, true);
+	DataChangeEvent	APPROVE_EVENT		= new DataChangeEvent(true, false);
+	DataChangeEvent	SIMPLE_UPDATE_EVENT	= new DataChangeEvent(false, false);
+	DataChangeEvent	RESTRUCTURE_EVENT	= new DataChangeEvent(false, true);
 
-	public void dataChanged(DataChangeEvent event);
+	void dataChanged(DataChangeEvent event);
 
-	public static class DataChangeEvent {
+	class DataChangeEvent {
 		public DataChangeEvent(boolean approved, boolean structureChange) {
 			this.approved = approved;
 			this.structureChange = structureChange;
 		}
 
-		public boolean	approved		= false;
-		public boolean	structureChange	= false;
+		public boolean	approved;
+		public boolean	structureChange;
 	}
 }

--- a/src/org/ohdsi/usagi/ui/Global.java
+++ b/src/org/ohdsi/usagi/ui/Global.java
@@ -19,21 +19,7 @@ import javax.swing.JFrame;
 
 import org.ohdsi.usagi.BerkeleyDbEngine;
 import org.ohdsi.usagi.UsagiSearchEngine;
-import org.ohdsi.usagi.ui.actions.AboutAction;
-import org.ohdsi.usagi.ui.actions.ApplyPreviousMappingAction;
-import org.ohdsi.usagi.ui.actions.ApproveAction;
-import org.ohdsi.usagi.ui.actions.ApproveAllAction;
-import org.ohdsi.usagi.ui.actions.ClearAllAction;
-import org.ohdsi.usagi.ui.actions.ConceptInformationAction;
-import org.ohdsi.usagi.ui.actions.ExitAction;
-import org.ohdsi.usagi.ui.actions.ExportForReviewAction;
-import org.ohdsi.usagi.ui.actions.ExportSourceToConceptMapAction;
-import org.ohdsi.usagi.ui.actions.ImportAction;
-import org.ohdsi.usagi.ui.actions.OpenAction;
-import org.ohdsi.usagi.ui.actions.RebuildIndexAction;
-import org.ohdsi.usagi.ui.actions.SaveAction;
-import org.ohdsi.usagi.ui.actions.SaveAsAction;
-import org.ohdsi.usagi.ui.actions.ShowStatsAction;
+import org.ohdsi.usagi.ui.actions.*;
 
 public class Global {
 	public static JFrame							frame;
@@ -57,6 +43,7 @@ public class Global {
 	public static ApproveAllAction					approveAllAction;
 	public static ClearAllAction					clearAllAction;
 	public static ConceptInformationAction			conceptInfoAction;
+	public static AthenaAction						athenaAction;
 	public static AboutAction						aboutAction;
 	public static ExportSourceToConceptMapAction	exportAction;
 	public static ExportForReviewAction				exportForReviewAction;

--- a/src/org/ohdsi/usagi/ui/Global.java
+++ b/src/org/ohdsi/usagi/ui/Global.java
@@ -44,6 +44,7 @@ public class Global {
 	public static ClearAllAction					clearAllAction;
 	public static ConceptInformationAction			conceptInfoAction;
 	public static AthenaAction						athenaAction;
+	public static GoogleSearchAction				googleSearchAction;
 	public static AboutAction						aboutAction;
 	public static ExportSourceToConceptMapAction	exportAction;
 	public static ExportForReviewAction				exportForReviewAction;

--- a/src/org/ohdsi/usagi/ui/MappingDetailPanel.java
+++ b/src/org/ohdsi/usagi/ui/MappingDetailPanel.java
@@ -199,21 +199,20 @@ public class MappingDetailPanel extends JPanel implements CodeSelectedListener, 
 		searchTable.setPreferredScrollableViewportSize(new Dimension(100, 100));
 		searchTable.setAutoResizeMode(JTable.AUTO_RESIZE_ALL_COLUMNS);
 		searchTable.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
-		searchTable.getSelectionModel().addListSelectionListener(new ListSelectionListener() {
-			public void valueChanged(ListSelectionEvent event) {
-				int viewRow = searchTable.getSelectedRow();
-				if (viewRow == -1) {
-					addButton.setEnabled(false);
-					replaceButton.setEnabled(false);
-				} else {
-					addButton.setEnabled(true);
-					replaceButton.setEnabled(true);
-					Global.conceptInfoAction.setEnabled(true);
-					int modelRow = searchTable.convertRowIndexToModel(viewRow);
-					Global.conceptInformationDialog.setConcept(searchTableModel.getConcept(modelRow));
-				}
+		searchTable.getSelectionModel().addListSelectionListener(event -> {
+			int viewRow = searchTable.getSelectedRow();
+			if (viewRow == -1) {
+				addButton.setEnabled(false);
+				replaceButton.setEnabled(false);
+			} else {
+				addButton.setEnabled(true);
+				replaceButton.setEnabled(true);
+				int modelRow = searchTable.convertRowIndexToModel(viewRow);
+				Global.conceptInfoAction.setEnabled(true);
+				Global.conceptInformationDialog.setConcept(searchTableModel.getConcept(modelRow));
+				Global.athenaAction.setEnabled(true);
+				Global.athenaAction.setConcept(searchTableModel.getConcept(modelRow));
 			}
-
 		});
 		// searchTable.hideColumn("Synonym");
 		searchTable.hideColumn("Valid start date");
@@ -321,19 +320,18 @@ public class MappingDetailPanel extends JPanel implements CodeSelectedListener, 
 		targetConceptTable.setPreferredScrollableViewportSize(new Dimension(500, 45));
 		targetConceptTable.setAutoResizeMode(JTable.AUTO_RESIZE_ALL_COLUMNS);
 		targetConceptTable.setRowSelectionAllowed(true);
-		targetConceptTable.getSelectionModel().addListSelectionListener(new ListSelectionListener() {
-			public void valueChanged(ListSelectionEvent event) {
-				int viewRow = targetConceptTable.getSelectedRow();
-				if (viewRow == -1) {
-					removeButton.setEnabled(false);
-				} else {
-					removeButton.setEnabled(true);
-					Global.conceptInfoAction.setEnabled(true);
-					int modelRow = targetConceptTable.convertRowIndexToModel(viewRow);
-					Global.conceptInformationDialog.setConcept(targetConceptTableModel.getConcept(modelRow));
-				}
+		targetConceptTable.getSelectionModel().addListSelectionListener(event -> {
+			int viewRow = targetConceptTable.getSelectedRow();
+			if (viewRow == -1) {
+				removeButton.setEnabled(false);
+			} else {
+				removeButton.setEnabled(true);
+				int modelRow = targetConceptTable.convertRowIndexToModel(viewRow);
+				Global.conceptInfoAction.setEnabled(true);
+				Global.conceptInformationDialog.setConcept(targetConceptTableModel.getConcept(modelRow));
+				Global.athenaAction.setEnabled(true);
+				Global.athenaAction.setConcept(targetConceptTableModel.getConcept(modelRow));
 			}
-
 		});
 		targetConceptTable.hideColumn("Valid start date");
 		targetConceptTable.hideColumn("Valid end date");

--- a/src/org/ohdsi/usagi/ui/MappingDetailPanel.java
+++ b/src/org/ohdsi/usagi/ui/MappingDetailPanel.java
@@ -212,6 +212,7 @@ public class MappingDetailPanel extends JPanel implements CodeSelectedListener, 
 				Global.conceptInformationDialog.setConcept(searchTableModel.getConcept(modelRow));
 				Global.athenaAction.setEnabled(true);
 				Global.athenaAction.setConcept(searchTableModel.getConcept(modelRow));
+				Global.googleSearchAction.setEnabled(false);
 			}
 		});
 		// searchTable.hideColumn("Synonym");
@@ -331,6 +332,7 @@ public class MappingDetailPanel extends JPanel implements CodeSelectedListener, 
 				Global.conceptInformationDialog.setConcept(targetConceptTableModel.getConcept(modelRow));
 				Global.athenaAction.setEnabled(true);
 				Global.athenaAction.setConcept(targetConceptTableModel.getConcept(modelRow));
+				Global.googleSearchAction.setEnabled(false);
 			}
 		});
 		targetConceptTable.hideColumn("Valid start date");

--- a/src/org/ohdsi/usagi/ui/MappingTablePanel.java
+++ b/src/org/ohdsi/usagi/ui/MappingTablePanel.java
@@ -52,26 +52,27 @@ public class MappingTablePanel extends JPanel implements DataChangeListener {
 		table.setPreferredScrollableViewportSize(new Dimension(1200, 200));
 		table.setSelectionMode(ListSelectionModel.MULTIPLE_INTERVAL_SELECTION);
 
-		table.getSelectionModel().addListSelectionListener(new ListSelectionListener() {
-			public void valueChanged(ListSelectionEvent event) {
-				if (!ignoreSelection) {
-					int viewRow = table.getSelectedRow();
-					if (viewRow != -1) {
-						int modelRow = table.convertRowIndexToModel(viewRow);
-						for (CodeSelectedListener listener : listeners)
-							listener.codeSelected(tableModel.getCodeMapping(modelRow));
-						Global.approveAction.setEnabled(true);
-						Global.approveAllAction.setEnabled(true);
-						Global.clearAllAction.setEnabled(true);
-						if (tableModel.getCodeMapping(modelRow).targetConcepts.size() > 0) {
-							Global.conceptInfoAction.setEnabled(true);
-							Global.conceptInformationDialog.setConcept(tableModel.getCodeMapping(modelRow).targetConcepts.get(0));
-						}
-					} else {
-						Global.approveAllAction.setEnabled(false);
-						Global.approveAction.setEnabled(false);
-						Global.clearAllAction.setEnabled(false);
+		table.getSelectionModel().addListSelectionListener(event -> {
+			if (!ignoreSelection) {
+				int viewRow = table.getSelectedRow();
+				if (viewRow != -1) {
+					int modelRow = table.convertRowIndexToModel(viewRow);
+					for (CodeSelectedListener listener : listeners)
+						listener.codeSelected(tableModel.getCodeMapping(modelRow));
+					Global.approveAction.setEnabled(true);
+					Global.approveAllAction.setEnabled(true);
+					Global.clearAllAction.setEnabled(true);
+					if (tableModel.getCodeMapping(modelRow).targetConcepts.size() > 0) {
+						Concept firstConcept = tableModel.getCodeMapping(modelRow).targetConcepts.get(0);
+						Global.conceptInfoAction.setEnabled(true);
+						Global.conceptInformationDialog.setConcept(firstConcept);
+						Global.athenaAction.setEnabled(true);
+						Global.athenaAction.setConcept(firstConcept);
 					}
+				} else {
+					Global.approveAllAction.setEnabled(false);
+					Global.approveAction.setEnabled(false);
+					Global.clearAllAction.setEnabled(false);
 				}
 			}
 		});

--- a/src/org/ohdsi/usagi/ui/MappingTablePanel.java
+++ b/src/org/ohdsi/usagi/ui/MappingTablePanel.java
@@ -57,8 +57,13 @@ public class MappingTablePanel extends JPanel implements DataChangeListener {
 				int viewRow = table.getSelectedRow();
 				if (viewRow != -1) {
 					int modelRow = table.convertRowIndexToModel(viewRow);
-					for (CodeSelectedListener listener : listeners)
+					for (CodeSelectedListener listener : listeners) {
 						listener.codeSelected(tableModel.getCodeMapping(modelRow));
+					}
+
+					Global.googleSearchAction.setEnabled(true);
+					Global.googleSearchAction.setSourceTerm(tableModel.getCodeMapping(modelRow).sourceCode.sourceName);
+
 					Global.approveAction.setEnabled(true);
 					Global.approveAllAction.setEnabled(true);
 					Global.clearAllAction.setEnabled(true);

--- a/src/org/ohdsi/usagi/ui/UsagiMain.java
+++ b/src/org/ohdsi/usagi/ui/UsagiMain.java
@@ -75,6 +75,7 @@ public class UsagiMain implements ActionListener {
 		Global.approveAction = new ApproveAction();
 		Global.conceptInfoAction = new ConceptInformationAction();
 		Global.athenaAction = new AthenaAction();
+		Global.googleSearchAction = new GoogleSearchAction();
 		Global.showStatsAction = new ShowStatsAction();
 		Global.aboutAction = new AboutAction();
 		Global.approveAllAction = new ApproveAllAction();
@@ -92,6 +93,7 @@ public class UsagiMain implements ActionListener {
 		Global.clearAllAction.setEnabled(false);
 		Global.conceptInfoAction.setEnabled(false);
 		Global.athenaAction.setEnabled(false);
+		Global.googleSearchAction.setEnabled(false);
 
 		frame.setDefaultCloseOperation(JFrame.DO_NOTHING_ON_CLOSE);
 		frame.addWindowListener(new WindowAdapter() {

--- a/src/org/ohdsi/usagi/ui/UsagiMain.java
+++ b/src/org/ohdsi/usagi/ui/UsagiMain.java
@@ -74,6 +74,7 @@ public class UsagiMain implements ActionListener {
 		Global.saveAsAction = new SaveAsAction();
 		Global.approveAction = new ApproveAction();
 		Global.conceptInfoAction = new ConceptInformationAction();
+		Global.athenaAction = new AthenaAction();
 		Global.showStatsAction = new ShowStatsAction();
 		Global.aboutAction = new AboutAction();
 		Global.approveAllAction = new ApproveAllAction();
@@ -90,6 +91,7 @@ public class UsagiMain implements ActionListener {
 		Global.clearAllAction = new ClearAllAction();
 		Global.clearAllAction.setEnabled(false);
 		Global.conceptInfoAction.setEnabled(false);
+		Global.athenaAction.setEnabled(false);
 
 		frame.setDefaultCloseOperation(JFrame.DO_NOTHING_ON_CLOSE);
 		frame.addWindowListener(new WindowAdapter() {

--- a/src/org/ohdsi/usagi/ui/UsagiMain.java
+++ b/src/org/ohdsi/usagi/ui/UsagiMain.java
@@ -40,12 +40,14 @@ import org.ohdsi.utilities.files.ReadTextFile;
  */
 public class UsagiMain implements ActionListener {
 
+	public static String version = "1.2.9-SNAPSHOT";
+
 	public static void main(String[] args) {
 		new UsagiMain(args);
 	}
 
 	public UsagiMain(String[] args) {
-		JFrame frame = new JFrame("Usagi");
+		JFrame frame = new JFrame("Usagi v" + UsagiMain.version);
 
 		// Initialize global variables:
 		Global.mapping = new Mapping();

--- a/src/org/ohdsi/usagi/ui/UsagiMenubar.java
+++ b/src/org/ohdsi/usagi/ui/UsagiMenubar.java
@@ -25,7 +25,7 @@ public class UsagiMenubar extends JMenuBar {
 
 	public UsagiMenubar() {
 		JMenu fileMenu = new JMenu("File");
-		fileMenu.setMnemonic(new Integer(KeyEvent.VK_F));
+		fileMenu.setMnemonic(KeyEvent.VK_F);
 		add(fileMenu);
 
 		fileMenu.add(Global.openAction);
@@ -38,7 +38,7 @@ public class UsagiMenubar extends JMenuBar {
 		fileMenu.add(Global.exitAction);
 
 		JMenu editMenu = new JMenu("Edit");
-		editMenu.setMnemonic(new Integer(KeyEvent.VK_E));
+		editMenu.setMnemonic(KeyEvent.VK_E);
 		add(editMenu);
 
 		editMenu.add(Global.approveAction);
@@ -46,13 +46,14 @@ public class UsagiMenubar extends JMenuBar {
 		editMenu.add(Global.clearAllAction);
 
 		JMenu viewMenu = new JMenu("View");
-		viewMenu.setMnemonic(new Integer(KeyEvent.VK_V));
+		viewMenu.setMnemonic(KeyEvent.VK_V);
 		add(viewMenu);
 
 		viewMenu.add(Global.conceptInfoAction);
+		viewMenu.add(Global.athenaAction);
 
 		JMenu helpMenu = new JMenu("Help");
-		helpMenu.setMnemonic(new Integer(KeyEvent.VK_H));
+		helpMenu.setMnemonic(KeyEvent.VK_H);
 		add(helpMenu);
 
 		helpMenu.add(Global.rebuildIndexAction);

--- a/src/org/ohdsi/usagi/ui/UsagiMenubar.java
+++ b/src/org/ohdsi/usagi/ui/UsagiMenubar.java
@@ -51,6 +51,7 @@ public class UsagiMenubar extends JMenuBar {
 
 		viewMenu.add(Global.conceptInfoAction);
 		viewMenu.add(Global.athenaAction);
+		viewMenu.add(Global.googleSearchAction);
 
 		JMenu helpMenu = new JMenu("Help");
 		helpMenu.setMnemonic(KeyEvent.VK_H);

--- a/src/org/ohdsi/usagi/ui/actions/AboutAction.java
+++ b/src/org/ohdsi/usagi/ui/actions/AboutAction.java
@@ -23,13 +23,14 @@ import javax.swing.Action;
 
 import org.ohdsi.usagi.ui.AboutDialog;
 import org.ohdsi.usagi.ui.Global;
+import org.ohdsi.usagi.ui.UsagiMain;
 
 public class AboutAction extends AbstractAction {
 
 	private static final long	serialVersionUID	= -6399524936473823131L;
 
 	public AboutAction() {
-		putValue(Action.NAME, "About Usagi");
+		putValue(Action.NAME, "About Usagi v" + UsagiMain.version);
 		putValue(Action.SHORT_DESCRIPTION, "About Usagi");
 		putValue(Action.MNEMONIC_KEY, KeyEvent.VK_A);
 	}

--- a/src/org/ohdsi/usagi/ui/actions/ApplyPreviousMappingAction.java
+++ b/src/org/ohdsi/usagi/ui/actions/ApplyPreviousMappingAction.java
@@ -28,6 +28,7 @@ import javax.swing.filechooser.FileFilter;
 import javax.swing.filechooser.FileNameExtensionFilter;
 
 import org.ohdsi.usagi.CodeMapping;
+import org.ohdsi.usagi.ui.DataChangeListener;
 import org.ohdsi.usagi.ui.Global;
 import org.ohdsi.usagi.ui.Mapping;
 
@@ -79,6 +80,7 @@ public class ApplyPreviousMappingAction extends AbstractAction {
 					+ " were applied to the current mapping and " + mappingsAdded + " were newly added.";
 			Global.mappingTablePanel.updateUI();
 			Global.mappingDetailPanel.updateUI();
+			Global.mapping.fireDataChanged(DataChangeListener.APPROVE_EVENT); // To update the footer
 			if (mappingsAdded > 0) {
 				Global.usagiSearchEngine.close();
 				Global.usagiSearchEngine.createDerivedIndex(Global.mapping.getSourceCodes(), Global.frame);

--- a/src/org/ohdsi/usagi/ui/actions/AthenaAction.java
+++ b/src/org/ohdsi/usagi/ui/actions/AthenaAction.java
@@ -1,0 +1,58 @@
+/*******************************************************************************
+ * Copyright 2019 Observational Health Data Sciences and Informatics
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+package org.ohdsi.usagi.ui.actions;
+
+import org.ohdsi.usagi.Concept;
+import org.ohdsi.usagi.ui.AboutDialog;
+import org.ohdsi.usagi.ui.Global;
+import org.ohdsi.usagi.ui.UsagiMain;
+
+import javax.swing.*;
+import java.awt.*;
+import java.awt.event.ActionEvent;
+import java.awt.event.InputEvent;
+import java.awt.event.KeyEvent;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+
+public class AthenaAction extends AbstractAction {
+
+	private static final long serialVersionUID = -25905854723973L;
+	private static final String ATHENA_URL = "https://athena.ohdsi.org/search-terms/terms/";
+	private Concept selectedConcept;
+
+	public AthenaAction() {
+		putValue(Action.NAME, "Athena (web)");
+		putValue(Action.SHORT_DESCRIPTION, "Link out to Athena web based concept browser, showing page of currently selected OMOP concept.");
+		putValue(Action.MNEMONIC_KEY, KeyEvent.VK_W);
+		putValue(Action.ACCELERATOR_KEY, KeyStroke.getKeyStroke(KeyEvent.VK_W, InputEvent.ALT_MASK));
+	}
+
+	@Override
+	public void actionPerformed(ActionEvent arg0) {
+		try {
+			Desktop desktop = Desktop.getDesktop();
+			desktop.browse(new URI(ATHENA_URL + selectedConcept.conceptId));
+		} catch (URISyntaxException | IOException ex) {
+
+		}
+	}
+
+	public void setConcept(Concept concept) {
+		selectedConcept = concept;
+	}
+}

--- a/src/org/ohdsi/usagi/ui/actions/ConceptInformationAction.java
+++ b/src/org/ohdsi/usagi/ui/actions/ConceptInformationAction.java
@@ -16,6 +16,7 @@
 package org.ohdsi.usagi.ui.actions;
 
 import java.awt.event.ActionEvent;
+import java.awt.event.InputEvent;
 import java.awt.event.KeyEvent;
 
 import javax.swing.AbstractAction;
@@ -32,7 +33,7 @@ public class ConceptInformationAction extends AbstractAction {
 		putValue(Action.NAME, "Concept information");
 		putValue(Action.SHORT_DESCRIPTION, "Show additional concept information");
 		putValue(Action.MNEMONIC_KEY, KeyEvent.VK_C);
-		putValue(Action.ACCELERATOR_KEY, KeyStroke.getKeyStroke(KeyEvent.VK_C, ActionEvent.ALT_MASK));
+		putValue(Action.ACCELERATOR_KEY, KeyStroke.getKeyStroke(KeyEvent.VK_C, InputEvent.ALT_MASK));
 	}
 
 	@Override

--- a/src/org/ohdsi/usagi/ui/actions/GoogleSearchAction.java
+++ b/src/org/ohdsi/usagi/ui/actions/GoogleSearchAction.java
@@ -1,0 +1,55 @@
+/*******************************************************************************
+ * Copyright 2019 Observational Health Data Sciences and Informatics
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+package org.ohdsi.usagi.ui.actions;
+
+import org.ohdsi.usagi.Concept;
+
+import javax.swing.*;
+import java.awt.*;
+import java.awt.event.ActionEvent;
+import java.awt.event.InputEvent;
+import java.awt.event.KeyEvent;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+
+public class GoogleSearchAction extends AbstractAction {
+
+	private static final long serialVersionUID = -934859464521233L;
+	private static final String GOOGLE_Q_URL = "https://www.google.com/search?q=";
+	private String sourceTerm;
+
+	public GoogleSearchAction() {
+		putValue(Action.NAME, "Google (web)");
+		putValue(Action.SHORT_DESCRIPTION, "Search source term on Google");
+		putValue(Action.MNEMONIC_KEY, KeyEvent.VK_G);
+		putValue(Action.ACCELERATOR_KEY, KeyStroke.getKeyStroke(KeyEvent.VK_G, InputEvent.ALT_MASK));
+	}
+
+	@Override
+	public void actionPerformed(ActionEvent arg0) {
+		try {
+			Desktop desktop = Desktop.getDesktop();
+			desktop.browse(new URI(GOOGLE_Q_URL + sourceTerm));
+		} catch (URISyntaxException | IOException ex) {
+
+		}
+	}
+
+	public void setSourceTerm(String sourceTerm) {
+		this.sourceTerm = sourceTerm;
+	}
+}


### PR DESCRIPTION
For source codes, add option to do a Google web search for the term. Either through the View menu or with alt-g. Fixes #66 

For OMOP concepts, adds option to navigate directly to Athena concept detail web page. Available in the view menu or with alt-w. 

Minor fixes:
 * Update the approved count  #45
 * Add version information in the About.
 * Disable editing of cells, which didn't have any effect.