### PR TITLE
Multi replace concept

### DIFF
--- a/src/org/ohdsi/usagi/ui/CodeSelectedListener.java
+++ b/src/org/ohdsi/usagi/ui/CodeSelectedListener.java
@@ -18,5 +18,7 @@ package org.ohdsi.usagi.ui;
 import org.ohdsi.usagi.CodeMapping;
 
 public interface CodeSelectedListener {
-	public void codeSelected(CodeMapping codeMapping);
+	void codeSelected(CodeMapping codeMapping);
+	void addCodeMultiSelected(CodeMapping codeMapping);
+	void clearCodeMultiSelected();
 }

--- a/src/org/ohdsi/usagi/ui/DataChangeListener.java
+++ b/src/org/ohdsi/usagi/ui/DataChangeListener.java
@@ -17,19 +17,22 @@ package org.ohdsi.usagi.ui;
 
 public interface DataChangeListener {
 
-	public static DataChangeEvent	APPROVE_EVENT		= new DataChangeEvent(true, false);
-	public static DataChangeEvent	SIMPLE_UPDATE_EVENT	= new DataChangeEvent(false, false);
-	public static DataChangeEvent	RESTRUCTURE_EVENT	= new DataChangeEvent(false, true);
+	public static DataChangeEvent	APPROVE_EVENT		= new DataChangeEvent(true, false, false);
+	public static DataChangeEvent	SIMPLE_UPDATE_EVENT	= new DataChangeEvent(false, false, false);
+	public static DataChangeEvent	MULTI_UPDATE_EVENT	= new DataChangeEvent(false, false, true);
+	public static DataChangeEvent	RESTRUCTURE_EVENT	= new DataChangeEvent(false, true, false);
 
 	public void dataChanged(DataChangeEvent event);
 
 	public static class DataChangeEvent {
-		public DataChangeEvent(boolean approved, boolean structureChange) {
+		public DataChangeEvent(boolean approved, boolean structureChange, boolean multiUpdate) {
 			this.approved = approved;
 			this.structureChange = structureChange;
+			this.multiUpdate = multiUpdate;
 		}
 
 		public boolean	approved		= false;
 		public boolean	structureChange	= false;
+		public boolean	multiUpdate	= false;
 	}
 }

--- a/src/org/ohdsi/usagi/ui/MappingDetailPanel.java
+++ b/src/org/ohdsi/usagi/ui/MappingDetailPanel.java
@@ -76,7 +76,7 @@ public class MappingDetailPanel extends JPanel implements CodeSelectedListener, 
 	private JRadioButton						manualQueryButton;
 	private JTextField							manualQueryField;
 	private CodeMapping							codeMapping;
-	private List<CodeMapping> 					codeMappingFromMulti;
+	private List<CodeMapping> 					codeMappingsFromMulti;
 	private FilterPanel							filterPanel;
 	private Timer								timer;
 
@@ -87,7 +87,7 @@ public class MappingDetailPanel extends JPanel implements CodeSelectedListener, 
 		add(createTargetConceptsPanel());
 		add(createSearchPanel());
 		add(createApprovePanel());
-		codeMappingFromMulti = new ArrayList<>();
+		codeMappingsFromMulti = new ArrayList<>();
 	}
 
 	private Component createSearchPanel() {
@@ -377,12 +377,12 @@ public class MappingDetailPanel extends JPanel implements CodeSelectedListener, 
 
 	@Override
 	public void addCodeMultiSelected(CodeMapping codeMapping) {
-		this.codeMappingFromMulti.add(codeMapping);
+		this.codeMappingsFromMulti.add(codeMapping);
 	}
 
 	@Override
 	public void clearCodeMultiSelected() {
-		this.codeMappingFromMulti = new ArrayList<>();
+		this.codeMappingsFromMulti = new ArrayList<>();
 	}
 
 	public void approve() {
@@ -410,16 +410,21 @@ public class MappingDetailPanel extends JPanel implements CodeSelectedListener, 
 
 	public void addConcept(Concept concept) {
 		codeMapping.targetConcepts.add(concept);
-		for (CodeMapping codeMappingMulti : codeMappingFromMulti) {
+		for (CodeMapping codeMappingMulti : codeMappingsFromMulti) {
 			codeMappingMulti.targetConcepts.add(concept);
 		}
 		targetConceptTableModel.fireTableDataChanged();
-		Global.mapping.fireDataChanged(DataChangeListener.SIMPLE_UPDATE_EVENT);
+
+		if (codeMappingsFromMulti.size() > 0) {
+			Global.mapping.fireDataChanged(DataChangeListener.MULTI_UPDATE_EVENT);
+		} else {
+			Global.mapping.fireDataChanged(DataChangeListener.SIMPLE_UPDATE_EVENT);
+		}
 	}
 
 	public void replaceConcepts(Concept concept) {
 		codeMapping.targetConcepts.clear();
-		for (CodeMapping codeMappingMulti : codeMappingFromMulti) {
+		for (CodeMapping codeMappingMulti : codeMappingsFromMulti) {
 			codeMappingMulti.targetConcepts.clear();
 		}
 		addConcept(concept);

--- a/src/org/ohdsi/usagi/ui/MappingDetailPanel.java
+++ b/src/org/ohdsi/usagi/ui/MappingDetailPanel.java
@@ -76,6 +76,7 @@ public class MappingDetailPanel extends JPanel implements CodeSelectedListener, 
 	private JRadioButton						manualQueryButton;
 	private JTextField							manualQueryField;
 	private CodeMapping							codeMapping;
+	private List<CodeMapping> 					codeMappingFromMulti;
 	private FilterPanel							filterPanel;
 	private Timer								timer;
 
@@ -86,6 +87,7 @@ public class MappingDetailPanel extends JPanel implements CodeSelectedListener, 
 		add(createTargetConceptsPanel());
 		add(createSearchPanel());
 		add(createApprovePanel());
+		codeMappingFromMulti = new ArrayList<>();
 	}
 
 	private Component createSearchPanel() {
@@ -373,6 +375,16 @@ public class MappingDetailPanel extends JPanel implements CodeSelectedListener, 
 		doSearch();
 	}
 
+	@Override
+	public void addCodeMultiSelected(CodeMapping codeMapping) {
+		this.codeMappingFromMulti.add(codeMapping);
+	}
+
+	@Override
+	public void clearCodeMultiSelected() {
+		this.codeMappingFromMulti = new ArrayList<>();
+	}
+
 	public void approve() {
 		if (codeMapping.mappingStatus != CodeMapping.MappingStatus.APPROVED) {
 			codeMapping.mappingStatus = CodeMapping.MappingStatus.APPROVED;
@@ -398,12 +410,18 @@ public class MappingDetailPanel extends JPanel implements CodeSelectedListener, 
 
 	public void addConcept(Concept concept) {
 		codeMapping.targetConcepts.add(concept);
+		for (CodeMapping codeMappingMulti : codeMappingFromMulti) {
+			codeMappingMulti.targetConcepts.add(concept);
+		}
 		targetConceptTableModel.fireTableDataChanged();
 		Global.mapping.fireDataChanged(DataChangeListener.SIMPLE_UPDATE_EVENT);
 	}
 
 	public void replaceConcepts(Concept concept) {
 		codeMapping.targetConcepts.clear();
+		for (CodeMapping codeMappingMulti : codeMappingFromMulti) {
+			codeMappingMulti.targetConcepts.clear();
+		}
 		addConcept(concept);
 	}
 

--- a/src/org/ohdsi/usagi/ui/MappingTablePanel.java
+++ b/src/org/ohdsi/usagi/ui/MappingTablePanel.java
@@ -56,15 +56,15 @@ public class MappingTablePanel extends JPanel implements DataChangeListener {
 			if (!ignoreSelection) {
 				int primaryViewRow = table.getSelectedRow();
 				if (primaryViewRow != -1) {
-					int modelRow = table.convertRowIndexToModel(primaryViewRow);
+					int primaryModelRow = table.convertRowIndexToModel(primaryViewRow);
 					for (CodeSelectedListener listener : listeners)
-						listener.codeSelected(tableModel.getCodeMapping(modelRow));
+						listener.codeSelected(tableModel.getCodeMapping(primaryModelRow));
 					Global.approveAction.setEnabled(true);
 					Global.approveAllAction.setEnabled(true);
 					Global.clearAllAction.setEnabled(true);
-					if (tableModel.getCodeMapping(modelRow).targetConcepts.size() > 0) {
+					if (tableModel.getCodeMapping(primaryModelRow).targetConcepts.size() > 0) {
 						Global.conceptInfoAction.setEnabled(true);
-						Global.conceptInformationDialog.setConcept(tableModel.getCodeMapping(modelRow).targetConcepts.get(0));
+						Global.conceptInformationDialog.setConcept(tableModel.getCodeMapping(primaryModelRow).targetConcepts.get(0));
 					}
 
 					// All other selected rows
@@ -258,6 +258,8 @@ public class MappingTablePanel extends JPanel implements DataChangeListener {
 		} else if (event.structureChange) {
 			tableModel.restructure();
 			table.setRowSelectionInterval(0, 0);
+		} else if (event.multiUpdate) {
+			tableModel.fireTableDataChanged();
 		} else {
 			tableModel.fireTableRowsUpdated(table.getSelectedRow(), table.getSelectedRow());
 		}

--- a/src/org/ohdsi/usagi/ui/MappingTablePanel.java
+++ b/src/org/ohdsi/usagi/ui/MappingTablePanel.java
@@ -52,26 +52,37 @@ public class MappingTablePanel extends JPanel implements DataChangeListener {
 		table.setPreferredScrollableViewportSize(new Dimension(1200, 200));
 		table.setSelectionMode(ListSelectionModel.MULTIPLE_INTERVAL_SELECTION);
 
-		table.getSelectionModel().addListSelectionListener(new ListSelectionListener() {
-			public void valueChanged(ListSelectionEvent event) {
-				if (!ignoreSelection) {
-					int viewRow = table.getSelectedRow();
-					if (viewRow != -1) {
-						int modelRow = table.convertRowIndexToModel(viewRow);
-						for (CodeSelectedListener listener : listeners)
-							listener.codeSelected(tableModel.getCodeMapping(modelRow));
-						Global.approveAction.setEnabled(true);
-						Global.approveAllAction.setEnabled(true);
-						Global.clearAllAction.setEnabled(true);
-						if (tableModel.getCodeMapping(modelRow).targetConcepts.size() > 0) {
-							Global.conceptInfoAction.setEnabled(true);
-							Global.conceptInformationDialog.setConcept(tableModel.getCodeMapping(modelRow).targetConcepts.get(0));
-						}
-					} else {
-						Global.approveAllAction.setEnabled(false);
-						Global.approveAction.setEnabled(false);
-						Global.clearAllAction.setEnabled(false);
+		table.getSelectionModel().addListSelectionListener(event -> {
+			if (!ignoreSelection) {
+				int primaryViewRow = table.getSelectedRow();
+				if (primaryViewRow != -1) {
+					int modelRow = table.convertRowIndexToModel(primaryViewRow);
+					for (CodeSelectedListener listener : listeners)
+						listener.codeSelected(tableModel.getCodeMapping(modelRow));
+					Global.approveAction.setEnabled(true);
+					Global.approveAllAction.setEnabled(true);
+					Global.clearAllAction.setEnabled(true);
+					if (tableModel.getCodeMapping(modelRow).targetConcepts.size() > 0) {
+						Global.conceptInfoAction.setEnabled(true);
+						Global.conceptInformationDialog.setConcept(tableModel.getCodeMapping(modelRow).targetConcepts.get(0));
 					}
+
+					// All other selected rows
+					for (CodeSelectedListener listener : listeners) {
+						listener.clearCodeMultiSelected();
+					}
+					for (int viewRow : table.getSelectedRows()) {
+						if (viewRow != -1 && viewRow != primaryViewRow) {
+							int modelRow = table.convertRowIndexToModel(viewRow);
+							for (CodeSelectedListener listener : listeners) {
+								listener.addCodeMultiSelected(tableModel.getCodeMapping(modelRow));
+							}
+						}
+					}
+				} else {
+					Global.approveAllAction.setEnabled(false);
+					Global.approveAction.setEnabled(false);
+					Global.clearAllAction.setEnabled(false);
 				}
 			}
 		});

--- a/src/org/ohdsi/usagi/ui/actions/ApproveAllAction.java
+++ b/src/org/ohdsi/usagi/ui/actions/ApproveAllAction.java
@@ -16,9 +16,10 @@
 package org.ohdsi.usagi.ui.actions;
 
 import java.awt.event.ActionEvent;
+import java.awt.event.InputEvent;
+import java.awt.event.KeyEvent;
 
-import javax.swing.AbstractAction;
-import javax.swing.Action;
+import javax.swing.*;
 
 import org.ohdsi.usagi.ui.Global;
 
@@ -29,6 +30,7 @@ public class ApproveAllAction extends AbstractAction {
 	public ApproveAllAction() {
 		putValue(Action.NAME, "Approve selected");
 		putValue(Action.SHORT_DESCRIPTION, "Approve all selected mappings");
+		putValue(Action.ACCELERATOR_KEY, KeyStroke.getKeyStroke(KeyEvent.VK_A, InputEvent.ALT_MASK | InputEvent.SHIFT_DOWN_MASK));
 	}
 
 	@Override

--- a/src/org/ohdsi/usagi/ui/actions/ExportForReviewAction.java
+++ b/src/org/ohdsi/usagi/ui/actions/ExportForReviewAction.java
@@ -46,6 +46,11 @@ public class ExportForReviewAction extends AbstractAction {
 
 	@Override
 	public void actionPerformed(ActionEvent arg0) {
+		if (Global.mapping.size() == 0) {
+			UsagiDialogs.warningNothingToExport();
+			return;
+		}
+
 		boolean exportUnapproved = UsagiDialogs.askExportUnapprovedMappings();
 
 		boolean hasApprovedMappings = false;
@@ -57,7 +62,7 @@ public class ExportForReviewAction extends AbstractAction {
 		}
 
 		if (!exportUnapproved && !hasApprovedMappings) {
-			UsagiDialogs.warningNothingToExport();
+			UsagiDialogs.warningNoApprovedToExport();
 			return;
 		}
 

--- a/src/org/ohdsi/usagi/ui/actions/ExportSourceToConceptMapAction.java
+++ b/src/org/ohdsi/usagi/ui/actions/ExportSourceToConceptMapAction.java
@@ -39,6 +39,11 @@ public class ExportSourceToConceptMapAction extends AbstractAction {
 
 	@Override
 	public void actionPerformed(ActionEvent arg0) {
+		if (Global.mapping.size() == 0) {
+			UsagiDialogs.warningNothingToExport();
+			return;
+		}
+
 		boolean exportUnapproved = UsagiDialogs.askExportUnapprovedMappings();
 
 		boolean hasApprovedMappings = false;
@@ -50,7 +55,7 @@ public class ExportSourceToConceptMapAction extends AbstractAction {
 		}
 
 		if (!exportUnapproved && !hasApprovedMappings) {
-			UsagiDialogs.warningNothingToExport();
+			UsagiDialogs.warningNoApprovedToExport();
 			return;
 		}
 

--- a/src/org/ohdsi/usagi/ui/actions/UsagiDialogs.java
+++ b/src/org/ohdsi/usagi/ui/actions/UsagiDialogs.java
@@ -23,6 +23,15 @@ public class UsagiDialogs {
     public static void warningNothingToExport() {
         JOptionPane.showMessageDialog(
                 Global.frame,
+                "There are no mappings, so nothing to export",
+                "Nothing to export",
+                JOptionPane.WARNING_MESSAGE
+        );
+    }
+
+    public static void warningNoApprovedToExport() {
+        JOptionPane.showMessageDialog(
+                Global.frame,
                 "There are no approved mappings, so nothing to export",
                 "Nothing to export",
                 JOptionPane.WARNING_MESSAGE


### PR DESCRIPTION
Replace/add a target concept to ALL source codes selected. As requested on the forums: https://forums.ohdsi.org/t/usagi-experience/1372/38

## Example
Let's say we want to map all 'pain' codes to one generic target concept, then we select them all in the source code panel (either by dragging, or picking selectively)
![image](https://user-images.githubusercontent.com/17825660/82029523-6e1f6200-9697-11ea-9d0b-49ba570156ff.png)

Then select the target concept from the bottom panel and click 'replace concept'. The result is shown below:
![image](https://user-images.githubusercontent.com/17825660/82029641-94450200-9697-11ea-9663-43ce26a1f275.png)

